### PR TITLE
feat(core): ImageInput 타일 Drag & Drop 교체 및 버그 수정

### DIFF
--- a/packages/core/src/components/Button/index.tsx
+++ b/packages/core/src/components/Button/index.tsx
@@ -116,8 +116,8 @@ export function Button({
         className,
       )}
       classNames={mergeClassNamesWithDefault(classNames)}
-      {...props}
       disabled={isDisabled}
+      {...props}
     >
       {isButtonLoading && <Loader color="currentColor" size={loaderSize} {...loaderProps} />}
       <span className={styles.Button__Label}>

--- a/packages/core/src/components/ImageInput/index.tsx
+++ b/packages/core/src/components/ImageInput/index.tsx
@@ -87,6 +87,14 @@ function ImageTile({
       onDelete={() => onDelete(item.id)}
       deleteAriaLabel="이미지 삭제"
       onTileClick={() => fileInputRef.current?.click()}
+      onFileDrop={(file) => {
+        if (accept) {
+          if (!accept.includes(file.type as ImageInputAccept[number])) return;
+        } else {
+          if (!file.type.startsWith('image/')) return;
+        }
+        onReplace(item.id, file);
+      }}
       actionBarExtra={
         !readOnly && hasEdit ? (
           <Button

--- a/packages/core/src/components/LottieInput/index.tsx
+++ b/packages/core/src/components/LottieInput/index.tsx
@@ -94,7 +94,7 @@ function LottieTile({
     return () => {
       cancelled = true;
     };
-  }, [asyncLoadKey, item.file]);
+  }, [asyncLoadKey, item.file, item.url]);
 
   return (
     <TileShell

--- a/packages/core/src/components/shared/MultiItemInput/TileShell.tsx
+++ b/packages/core/src/components/shared/MultiItemInput/TileShell.tsx
@@ -4,6 +4,7 @@ import { defaultAnimateLayoutChanges, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Loader } from '@mantine/core';
 import { ColorAqua500, IconDragMenu, IconXCircle } from '@pop-ui/foundation';
+import { useState } from 'react';
 
 import styles from './styles.module.scss';
 
@@ -26,6 +27,7 @@ interface ITileShellProps {
   deleteAriaLabel?: string;
   actionBarExtra?: ReactNode;
   onTileClick?: () => void;
+  onFileDrop?: (file: File) => void;
   children: ReactNode;
 }
 
@@ -45,8 +47,36 @@ export function TileShell({
   deleteAriaLabel = '삭제',
   actionBarExtra,
   onTileClick,
+  onFileDrop,
   children,
 }: ITileShellProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent) => {
+    if (!onFileDrop || readOnly || isLoading || itemIsLoading) return;
+    e.preventDefault();
+  };
+
+  const handleDragEnter = (e: React.DragEvent) => {
+    if (!onFileDrop || readOnly || isLoading || itemIsLoading) return;
+    e.preventDefault();
+    setIsDragOver(true);
+  };
+
+  const handleDragLeave = (e: React.DragEvent) => {
+    if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+      setIsDragOver(false);
+    }
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    if (!onFileDrop || readOnly || isLoading || itemIsLoading) return;
+    const file = e.dataTransfer.files[0];
+    if (file) onFileDrop(file);
+  };
+
   const animateLayoutChanges: AnimateLayoutChanges = (args) => {
     const { isSorting, wasDragging } = args;
     if (isSorting || wasDragging) return false;
@@ -86,9 +116,13 @@ export function TileShell({
       )}
 
       <div
-        className={styles.Tile}
+        className={`${styles.Tile}${isDragOver ? ` ${styles.TileDragOver}` : ''}`}
         style={{ width, height, cursor: tileCursor }}
         onClick={() => !readOnly && !isLoading && !itemIsLoading && onTileClick?.()}
+        onDragOver={handleDragOver}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       >
         {children}
         {(isLoading || itemIsLoading) && (

--- a/packages/core/src/components/shared/MultiItemInput/styles.module.scss
+++ b/packages/core/src/components/shared/MultiItemInput/styles.module.scss
@@ -35,6 +35,12 @@
   border: 1px solid $color-gray-100;
   overflow: hidden;
   flex-shrink: 0;
+  transition: opacity 0.2s ease, border-color 0.2s ease;
+}
+
+.TileDragOver {
+  opacity: 0.7;
+  border-color: $color-aqua-500;
 }
 
 .LoadingOverlay {


### PR DESCRIPTION
## Summary
- ImageInput 기존 이미지 타일에 파일 Drag & Drop으로 바로 교체할 수 있는 기능 추가
  - accept 타입 필터링, readOnly/isLoading 상태 드롭 비활성화
  - 드래그 오버 시 시각적 피드백
- **fix(button)**: `{...props}` spread 순서를 `disabled` 뒤로 이동하여 사용자 props(type, onClick 등) 오버라이드 허용
- **fix(core)**: LottieTile useEffect 의존성에 `item.url` 추가하여 URL 변경 시 미리보기 갱신

## Test plan
- [ ] Storybook에서 ImageInput 이미지 타일 위에 파일 드래그 → 오버레이 피드백 확인 → 드롭 시 이미지 교체 확인
- [ ] readOnly / isLoading 상태에서 드롭 무시 확인
- [ ] accept 타입과 다른 파일 드롭 시 무시 확인
- [ ] 기존 클릭 교체 기능 정상 동작 확인
- [ ] Button에 type="submit" 전달 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)