### PR TITLE
[DPN-1212] CODEOWNERS 추가

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-*                    @datepop/frontend
+# DatePOP code owners
+# DPN-1212 GitHub repository governance rollout
+* @datepop/frontend @datepop/manager


### PR DESCRIPTION
DPN-1212 GitHub repository governance rollout.

- Add .github/CODEOWNERS
- Request owner team and manager reviews automatically
- Keep required code owner review disabled