### PR TITLE
chore(release): bump @pop-ui/{foundation,core}@1.1.9

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pop-ui/core",
   "type": "module",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/core.umd.cjs",
   "module": "./dist/core.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pop-ui/foundation",
   "type": "module",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "main": "./dist/foundation.umd.cjs",
   "module": "./dist/foundation.js",
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
## 변경 유형
- [ ] 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 핫픽스 (hotfix)
- [x] 기타 (chore)

## 관련 티켓
- DPN-1472 (후속)

## 변경 위험도
- [x] Low
- [ ] Medium
- [ ] High

## 변경 요약
이전 PR #108(`Release 2026.06.12`) 머지를 통해 `main`에 들어간 신규 브랜드 아이콘·일러스트·brand 카테고리(PR #107)를 NPM으로 publish하기 위한 monorepo **단일 버전 bump**입니다.

- `packages/foundation/package.json`: `1.1.8` → `1.1.9`
- `packages/core/package.json`: `1.1.8` → `1.1.9`

`core`는 코드 변경 없지만, `Jenkinsfile`의 `required: true` 패키지 검증(`Jenkinsfile:198-200`) 통과를 위해 단일 버전 정책에 따라 동일 버전으로 함께 bump 합니다.

## 영향 범위 / 롤백 포인트
- **영향 범위**: NPM publish 대상 두 패키지의 manifest version만 변경. 런타임 동작/공개 API 영향 없음.
- **롤백 포인트**: 머지 commit 1개 revert로 즉시 복원. 단, 이미 `v1.1.9` 태그 push 후 publish가 완료된 뒤에는 NPM 측 deprecate가 필요할 수 있음 → **머지 → 태그 push 사이에 최종 확인 권장**.

## 테스트 방법
```bash
# 1. 빌드 검증 (이미 PR check로 자동 실행됨)
yarn install && yarn build

# 2. 의존성 정합성 — core가 foundation을 workspace로 의존
grep -A1 '"@pop-ui/foundation"' packages/core/package.json
#   "@pop-ui/foundation": "workspace:*"  ← Jenkinsfile:217-219 검증 통과

# 3. 머지 후 main에서 태그 push로 publish 트리거
git checkout main && git pull
git tag v1.1.9
git push origin v1.1.9
#   → Jenkins 'Publish to NPM' stage 자동 실행
#   → @pop-ui/foundation@1.1.9, @pop-ui/core@1.1.9 publish
#   → GitHub Release 자동 생성
```

## 테스트 증거
- ✅ 로컬 `lerna typecheck` 통과 (pre-commit hook)
- ⏳ Jenkins `continuous-integration/jenkins/pr-merge` PR check

## 스크린샷 (UI 변경 시)
> 해당 없음 (manifest version만 변경)

## 체크리스트
- [x] 셀프 리뷰 완료
- [x] 관련 테스트 추가/수정 — 변경 범위 없음
- [x] 문서 업데이트 (필요 시) — 변경 범위 없음
- [x] High 위험도 또는 CTO 필수 개입 항목 해당 시 에스컬레이션 여부 확인 — Low

---

### 머지 직후 작업
```bash
git checkout main && git pull origin main
git tag v1.1.9
git push origin v1.1.9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
