### PR TITLE
[DPN-1579] H1 타이포 토큰명 정정 (H1-36-bold → H1-40-bold)

### DIFF
--- a/packages/foundation/token.json
+++ b/packages/foundation/token.json
@@ -401,7 +401,7 @@
       }
     },
     "web": {
-      "H1-36-bold": {
+      "H1-40-bold": {
         "value": {
           "fontFamily": "{font-family-Pretendard}",
           "fontWeight": "{font-weight-bold}",

--- a/packages/foundation/transformed-token.json
+++ b/packages/foundation/transformed-token.json
@@ -400,7 +400,7 @@
     }
   },
   "web": {
-    "H1-36-bold": {
+    "H1-40-bold": {
       "fontFamily": {
         "value": "Pretendard",
         "type": "fontFamilies"


### PR DESCRIPTION
## 배경
`@pop-ui/foundation`의 H1 타이포 토큰명이 실제 크기와 불일치 (이름 `H1-36-bold`, 실제 참조 `font-size-1100`=40px). 피그마 PDS는 이미 `Web/Header/40-Bold`로 올바르게 명명되어 있어 코드 토큰명만 어긋난 상태였음. (H2~C2는 이름의 숫자=실제 px로 정상)

## 변경
- 토큰 키 `H1-36-bold` → `H1-40-bold` (값 불변: 40px / bold / lineHeight 130% / Pretendard)
- `transformed-token.json`은 `yarn token-transform`으로 재생성 (diff는 키 한 줄로 제한 확인)

## 파장 범위 (안전)
- pop-ui 레포 내 `H1-36` 참조: 위 2개 JSON 외 0건
- 소비 앱 `inhouse` / `datepop-web`: 직접 참조 0건
- 토큰명을 문자열로 직접 참조하는 코드 없음 → 비파괴 minor

## 검증
- `grep -rn "H1-36" packages/` → 0건
- foundation 빌드 성공, pre-commit typecheck 통과
- 기존 lint/test 실패는 pre-existing (변경 전후 동일, 토큰과 무관)

## 릴리즈
- 소비 앱은 npm 배포 버전 사용 → 실제 반영은 `@pop-ui/foundation` 재배포 후 앱 버전 업 필요
- 다음 정기 릴리즈에 포함 (단독 핫픽스 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)