### PR TITLE
chore: gitignore에 docs/superpowers/ 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ packages/foundation/src/icons/native/
 packages/foundation/src/illustrations/native/
 packages/foundation/src/brand/native/
 
+# Brainstorming/spec 설계 문서 (로컬 전용)
+docs/superpowers/
+
 # General
 .DS_Store
 .AppleDouble


### PR DESCRIPTION
## 변경
- `.gitignore`에 `docs/superpowers/` 추가

## 이유
brainstorming/plan 등 로컬 전용 설계 문서가 git에 추적되지 않도록 제외. 팀원 모두 동일하게 무시하게 됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)