### PR TITLE
release: v1.1.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ packages/foundation/src/icons/native/
 packages/foundation/src/illustrations/native/
 packages/foundation/src/brand/native/
 
+# Brainstorming/spec 설계 문서 (로컬 전용)
+docs/superpowers/
+
 # General
 .DS_Store
 .AppleDouble

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pop-ui/core",
   "type": "module",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "main": "./dist/core.umd.cjs",
   "module": "./dist/core.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pop-ui/foundation",
   "type": "module",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "main": "./dist/foundation.umd.cjs",
   "module": "./dist/foundation.js",
   "types": "./dist/types/index.d.ts",

--- a/packages/foundation/token.json
+++ b/packages/foundation/token.json
@@ -401,7 +401,7 @@
       }
     },
     "web": {
-      "H1-36-bold": {
+      "H1-40-bold": {
         "value": {
           "fontFamily": "{font-family-Pretendard}",
           "fontWeight": "{font-weight-bold}",

--- a/packages/foundation/transformed-token.json
+++ b/packages/foundation/transformed-token.json
@@ -400,7 +400,7 @@
     }
   },
   "web": {
-    "H1-36-bold": {
+    "H1-40-bold": {
       "fontFamily": {
         "value": "Pretendard",
         "type": "fontFamilies"


### PR DESCRIPTION
## 릴리즈 v1.1.10

`@pop-ui/core`·`@pop-ui/foundation` 1.1.9 → 1.1.10 (patch)

## 포함 변경
- **[DPN-1579]** H1 타이포 토큰명 정정 `H1-36-bold` → `H1-40-bold` (#111)
  - 값 불변 (40px / bold / 130%), 참조처 0건 → 비파괴
- **chore** `.gitignore`에 `docs/superpowers/` 추가 (#112)

## 릴리즈 절차 (README 기준)
1. ✅ `release/*` 브랜치에서 두 패키지 버전 1.1.10으로 bump
2. ⬜ `datepop-deploy/pop-ui/release/*` Chromatic staging 검증
3. ⬜ 이 PR을 `main`에 머지
4. ⬜ `main` 커밋에 `v1.1.10` 태그 push → Jenkins가 npm publish

## 체크
- foundation/core 버전 동일 (1.1.10) ✅
- diff: 토큰 2파일 + gitignore + 버전 2파일 (노이즈 없음) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)