### PR TITLE
fix(button): 로딩 동작을 스펙에 맞춤 (라벨 숨김 + Mantine loading 가로채기)

### DIFF
--- a/packages/core/src/components/Button/index.tsx
+++ b/packages/core/src/components/Button/index.tsx
@@ -93,7 +93,8 @@ export function Button({
   variant = 'primary',
   type = 'button',
   isLoading = false,
-  hideLabelOnLoading = false,
+  loading = false,
+  hideLabelOnLoading = true,
   disabled = false,
   className,
   classNames,
@@ -101,7 +102,9 @@ export function Button({
   ...props
 }: IButtonProps) {
   const loaderSize = BUTTON_LOADER_SIZES[size];
-  const isButtonLoading = isLoading;
+  // Mantine `loading`도 로딩 트리거로 받되, unstyled 모드에서 깨지는 Mantine 로더로 전달되지 않도록
+  // 구조분해로 가로채 자체 Loader만 렌더한다.
+  const isButtonLoading = isLoading || loading;
   const isDisabled = disabled || isButtonLoading;
 
   return (

--- a/packages/foundation/src/illustrations/Illustrations.stories.tsx
+++ b/packages/foundation/src/illustrations/Illustrations.stories.tsx
@@ -1,6 +1,8 @@
 import { Stack, Text, Paper, Box, TextInput, Button, Group, Select } from '@mantine/core';
 import React, { useState } from 'react';
+
 import { illustrationMetadata, IllustrationCategory } from './metadata';
+
 import type { IIllustrationProps } from '../types/illustration';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
@@ -128,8 +130,7 @@ export const AllIllustrations: StoryObj<{ size: number }> = {
     const filtered = illustrationList.filter((item) => {
       const matchSearch = item.name.toLowerCase().includes(searchTerm.toLowerCase());
       const matchCategory =
-        !categoryFilter ||
-        (item.categories as readonly string[]).includes(categoryFilter);
+        !categoryFilter || (item.categories as readonly string[]).includes(categoryFilter);
       return matchSearch && matchCategory;
     });
 


### PR DESCRIPTION
## 배경

@pop-ui/core의 Button 테스트 23개가 기존부터 실패 상태였음(PR #120 작업 중 발견). 원인 규명 결과 mock 버그가 아니라 미완성 TDD — 테스트는 로딩 동작 스펙을 규정하는데 구현이 안 따라가고 있었음. 테스트를 스펙으로 보고 구현을 맞춤.

이 PR은 PR #120(컨벤션 정리) 위에 쌓여 있음. base가 worktree-ai-ready-conventions라 #120이 먼저 머지된 뒤 main 대상으로 전환 필요.

## 변경 (index.tsx 한 파일)

1. hideLabelOnLoading 기본값 false→true: 로딩 중 기본으로 라벨 숨기고 스피너만.
2. Mantine loading prop 수용+가로채기: isButtonLoading = isLoading || loading. loading을 구조분해로 꺼내 Mantine에 전달 안 되게(unstyled 로더 깨짐 방지).
3. loaderProps는 이미 지원(Mantine 상속).

## Breaking (미세)

hideLabelOnLoading 기본값이 바뀌어 로딩 중 텍스트가 사라짐(이전엔 유지). 텍스트 유지 필요시 hideLabelOnLoading={false}.

## 검증

- Button 테스트 23 fail → 33 pass
- yarn typecheck, build:core 통과
- 나머지 7개 파일 실패는 무관(foundation resolve 환경 문제, Button 원복해도 동일 재현)

🤖 Generated with [Claude Code](https://claude.com/claude-code)