### PR TITLE
refactor(core): prop 타입 단일원천화 + 공개 API로 export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ Button, CalendarDatePicker, Checkbox, DatePicker, Dropdown, ImageInput, LottieIn
 - **type/union은 `T` 접두사**: `TButtonSize`, `TDayOfWeek`, `TImageInputAccept`.
 - Props 타입은 `IXxxProps` 형태로 전 컴포넌트 일관. 접두사 벗긴 이름(`ButtonProps`)은 쓰지 않는다.
 - 타입 정의 파일명은 **`types.ts`**(복수). `type.ts` 아님.
+- **prop 타입은 반드시 `types.ts`에 정의**한다. `index.tsx` 인라인 정의 금지 — 전 컴포넌트가 `types.ts`를 갖는다(단일 진실원천).
+- **prop 타입은 barrel(`components/index.ts`)에서 export**한다: `export { Xxx }` 바로 아래에 `export type { IXxxProps } from './Xxx/types';`. 런타임 const(예: `BUTTON_SIZES`)는 `export type`가 아닌 값 export로 분리한다.
+- **union인 prop 타입은 `TXxxProps`(T 접두사)로 둔다.** interface로 표현할 수 없어서다(예: TextField의 `TTextFieldProps`). 레포 eslint(`@typescript-eslint/naming-convention`)가 type alias에 `T`를 강제하므로 `IXxxProps` 별칭을 만들지 않는다.
 
 ### size
 
@@ -71,7 +74,7 @@ Button, CalendarDatePicker, Checkbox, DatePicker, Dropdown, ImageInput, LottieIn
 
 1. **Mantine에 있으면 래핑**(자체 구현 지양). compound 패턴은 사내 전용 맥락에선 지양 — 필요하면 Mantine이 제공하는 compound API를 노출.
 2. named export만. `export const X`.
-3. Props는 `IXxxProps`(interface), union은 `TXxx`. 타입은 `types.ts`에.
+3. Props는 `IXxxProps`(interface), union은 `TXxx`. 타입은 **반드시 `types.ts`에** 정의하고 **barrel에서 export**(`export type { IXxxProps } from './Xxx/types'`).
 4. `size` 노출 시 `sm|md|lg` 3단계. 폭 같은 다른 의미면 그 사실을 주석/문서에 명시.
 5. 자체 boolean은 `is*`, 상속 boolean은 그대로.
 6. 숫자 radius/색상은 foundation 토큰 상수 사용.

--- a/packages/core/src/components/Checkbox/index.tsx
+++ b/packages/core/src/components/Checkbox/index.tsx
@@ -4,7 +4,7 @@ import { Checkbox as MantineCheckbox } from '@mantine/core';
 
 import styles from './styles.module.scss';
 
-import type { CheckboxProps as MantineCheckboxProps } from '@mantine/core';
+import type { ICheckboxProps } from './types';
 
 const CHECKBOX_CLASS_NAME_BY_SIZE = {
   sm: styles['Checkbox--Small'],
@@ -17,10 +17,6 @@ const CHECKBOX_DIMENSION_BY_SIZE = {
   md: 24,
   lg: 32,
 } as const;
-
-export interface ICheckboxProps extends MantineCheckboxProps {
-  size?: 'sm' | 'md' | 'lg';
-}
 
 export const Checkbox = ({ size = 'md', ...props }: ICheckboxProps) => {
   const sizeClassName = CHECKBOX_CLASS_NAME_BY_SIZE[size];

--- a/packages/core/src/components/Checkbox/types.ts
+++ b/packages/core/src/components/Checkbox/types.ts
@@ -1,0 +1,5 @@
+import type { CheckboxProps as MantineCheckboxProps } from '@mantine/core';
+
+export interface ICheckboxProps extends MantineCheckboxProps {
+  size?: 'sm' | 'md' | 'lg';
+}

--- a/packages/core/src/components/DatePicker/index.tsx
+++ b/packages/core/src/components/DatePicker/index.tsx
@@ -18,14 +18,13 @@ import {
   resolveDatePickerValue,
 } from '../CalendarDatePicker/utils';
 
+import type { IDatePickerProps } from './types';
 import type {
   TMantineClassNameRecord,
   TMantineClassNamesResolver,
-  TDayOfWeek,
 } from '../CalendarDatePicker/types';
 import type { PopoverProps, PopoverStylesNames } from '@mantine/core';
 import type { DateTimePickerProps, DateTimePickerStylesNames, DateValue } from '@mantine/dates';
-import type { TDateDisplayType } from '@pop-ui/foundation';
 
 const DEFAULT_DATE_TIME_CLASS_NAMES = {
   wrapper: styles.DatePicker__Wrapper,
@@ -83,37 +82,6 @@ const toDateOrNull = (v: DateValue | null | undefined): Date | null => {
   }
   return null;
 };
-
-export interface IDatePickerProps {
-  size?: 'sm' | 'md' | 'lg';
-  type?: TDateDisplayType;
-  withTime?: boolean;
-  // 값 제어
-  value?: string | null | string[] | [string | null, string | null];
-  defaultValue?: string | null | string[] | [string | null, string | null];
-  onChange?: (value: string | null | string[] | [string | null, string | null]) => void;
-  // Input 외관
-  placeholder?: string;
-  label?: React.ReactNode;
-  description?: React.ReactNode;
-  error?: React.ReactNode;
-  disabled?: boolean;
-  clearable?: boolean;
-  // 날짜 제약
-  minDate?: Date;
-  maxDate?: Date;
-  displayValueFormat?: string; // 입력창 표시 형식. 기본: 'YYYY년 MM월 DD일'
-  valueFormat?: string; // onChange emit 형식. 기본: 'YYYY-MM-DD'
-  // CalendarDatePicker 전용
-  excludedDates?: (string | [string, string])[];
-  excludedDays?: TDayOfWeek[];
-  highlightToday?: boolean;
-  // 스타일
-  className?: string;
-  popoverProps?: PopoverProps;
-  rightSection?: React.ReactNode;
-  rightSectionWidth?: number;
-}
 
 export const DatePicker = ({
   size = 'md',

--- a/packages/core/src/components/DatePicker/types.ts
+++ b/packages/core/src/components/DatePicker/types.ts
@@ -1,0 +1,35 @@
+import type { TDayOfWeek } from '../CalendarDatePicker/types';
+import type { PopoverProps } from '@mantine/core';
+import type { TDateDisplayType } from '@pop-ui/foundation';
+import type { ReactNode } from 'react';
+
+export interface IDatePickerProps {
+  size?: 'sm' | 'md' | 'lg';
+  type?: TDateDisplayType;
+  withTime?: boolean;
+  // 값 제어
+  value?: string | null | string[] | [string | null, string | null];
+  defaultValue?: string | null | string[] | [string | null, string | null];
+  onChange?: (value: string | null | string[] | [string | null, string | null]) => void;
+  // Input 외관
+  placeholder?: string;
+  label?: ReactNode;
+  description?: ReactNode;
+  error?: ReactNode;
+  disabled?: boolean;
+  clearable?: boolean;
+  // 날짜 제약
+  minDate?: Date;
+  maxDate?: Date;
+  displayValueFormat?: string; // 입력창 표시 형식. 기본: 'YYYY년 MM월 DD일'
+  valueFormat?: string; // onChange emit 형식. 기본: 'YYYY-MM-DD'
+  // CalendarDatePicker 전용
+  excludedDates?: (string | [string, string])[];
+  excludedDays?: TDayOfWeek[];
+  highlightToday?: boolean;
+  // 스타일
+  className?: string;
+  popoverProps?: PopoverProps;
+  rightSection?: ReactNode;
+  rightSectionWidth?: number;
+}

--- a/packages/core/src/components/Dropdown/index.tsx
+++ b/packages/core/src/components/Dropdown/index.tsx
@@ -6,17 +6,8 @@ import { useState } from 'react';
 
 import styles from './styles.module.scss';
 
-import type { SelectProps, CSSProperties } from '@mantine/core';
-
-export interface IDropdownProps extends SelectProps {
-  label?: string;
-  labelPosition?: 'top' | 'left';
-  size?: 'sm' | 'md' | 'lg';
-  tooltip?: string;
-  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
-  description?: string;
-  errorMsg?: string;
-}
+import type { IDropdownProps } from './types';
+import type { CSSProperties } from '@mantine/core';
 
 export const Dropdown = ({
   label,

--- a/packages/core/src/components/Dropdown/types.ts
+++ b/packages/core/src/components/Dropdown/types.ts
@@ -1,0 +1,11 @@
+import type { SelectProps } from '@mantine/core';
+
+export interface IDropdownProps extends SelectProps {
+  label?: string;
+  labelPosition?: 'top' | 'left';
+  size?: 'sm' | 'md' | 'lg';
+  tooltip?: string;
+  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
+  description?: string;
+  errorMsg?: string;
+}

--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -3,12 +3,7 @@
 import { Modal as MantineModal } from '@mantine/core';
 import { ColorGray600, ColorGray900, IconX } from '@pop-ui/foundation';
 
-import type { ModalProps as MantineModalProps } from '@mantine/core';
-
-export interface IModalProps extends MantineModalProps {
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-  width?: number;
-}
+import type { IModalProps } from './types';
 
 export const Modal = ({ size = 'md', width, withCloseButton = false, ...props }: IModalProps) => {
   let sizeNumber = 768;

--- a/packages/core/src/components/Modal/types.ts
+++ b/packages/core/src/components/Modal/types.ts
@@ -1,0 +1,6 @@
+import type { ModalProps as MantineModalProps } from '@mantine/core';
+
+export interface IModalProps extends MantineModalProps {
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  width?: number;
+}

--- a/packages/core/src/components/Pagination/index.tsx
+++ b/packages/core/src/components/Pagination/index.tsx
@@ -5,15 +5,7 @@ import { useEffect, useState } from 'react';
 
 import style from './style.module.scss';
 
-import type { HTMLAttributes } from 'react';
-
-export interface IPaginationProps extends HTMLAttributes<HTMLDivElement> {
-  currentPageIdx: number;
-  rowsPerPage?: number;
-  totalLength?: number;
-  paginationSize?: number;
-  onPageChange?: (e: number) => void;
-}
+import type { IPaginationProps } from './types';
 
 export const Pagination = ({
   currentPageIdx,

--- a/packages/core/src/components/Pagination/types.ts
+++ b/packages/core/src/components/Pagination/types.ts
@@ -1,0 +1,9 @@
+import type { HTMLAttributes } from 'react';
+
+export interface IPaginationProps extends HTMLAttributes<HTMLDivElement> {
+  currentPageIdx: number;
+  rowsPerPage?: number;
+  totalLength?: number;
+  paginationSize?: number;
+  onPageChange?: (e: number) => void;
+}

--- a/packages/core/src/components/Radio/index.tsx
+++ b/packages/core/src/components/Radio/index.tsx
@@ -4,7 +4,7 @@ import { Radio as MantineRadio } from '@mantine/core';
 
 import styles from './styles.module.scss';
 
-import type { RadioProps as MantineRadioProps } from '@mantine/core';
+import type { IRadioProps } from './types';
 
 const RADIO_CLASS_NAME_BY_SIZE = {
   sm: styles['Radio--Small'],
@@ -17,10 +17,6 @@ const RADIO_DIMENSION_BY_SIZE = {
   md: 24,
   lg: 32,
 } as const;
-
-export interface IRadioProps extends MantineRadioProps {
-  size?: 'sm' | 'md' | 'lg';
-}
 
 export const Radio = ({ size = 'md', ...props }: IRadioProps) => {
   const sizeClassName = RADIO_CLASS_NAME_BY_SIZE[size];

--- a/packages/core/src/components/Radio/types.ts
+++ b/packages/core/src/components/Radio/types.ts
@@ -1,0 +1,5 @@
+import type { RadioProps as MantineRadioProps } from '@mantine/core';
+
+export interface IRadioProps extends MantineRadioProps {
+  size?: 'sm' | 'md' | 'lg';
+}

--- a/packages/core/src/components/SearchBar/index.tsx
+++ b/packages/core/src/components/SearchBar/index.tsx
@@ -6,19 +6,7 @@ import { useCallback, useState } from 'react';
 
 import styles from './styles.module.scss';
 
-import type { AutocompleteProps } from '@mantine/core';
-
-export interface ISearchBarProps extends AutocompleteProps {
-  label?: string;
-  labelPosition?: 'top' | 'left';
-  size?: 'sm' | 'md' | 'lg';
-  tooltip?: string;
-  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
-  description?: string;
-  errorMsg?: string;
-  onChange?: (value: string) => void;
-  onClear?: () => void;
-}
+import type { ISearchBarProps } from './types';
 
 export const SearchBar = ({
   label,

--- a/packages/core/src/components/SearchBar/types.ts
+++ b/packages/core/src/components/SearchBar/types.ts
@@ -1,0 +1,13 @@
+import type { AutocompleteProps } from '@mantine/core';
+
+export interface ISearchBarProps extends AutocompleteProps {
+  label?: string;
+  labelPosition?: 'top' | 'left';
+  size?: 'sm' | 'md' | 'lg';
+  tooltip?: string;
+  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
+  description?: string;
+  errorMsg?: string;
+  onChange?: (value: string) => void;
+  onClear?: () => void;
+}

--- a/packages/core/src/components/SegmentButton/index.tsx
+++ b/packages/core/src/components/SegmentButton/index.tsx
@@ -5,12 +5,7 @@ import { BorderRadius150 } from '@pop-ui/foundation';
 
 import styles from './styles.module.scss';
 
-import type { SegmentedControlProps } from '@mantine/core';
-
-export interface ISegmentButtonProps extends SegmentedControlProps {
-  size?: 'sm' | 'md' | 'lg';
-  radius?: number | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-}
+import type { ISegmentButtonProps } from './types';
 
 export const SegmentButton = ({
   size = 'md',

--- a/packages/core/src/components/SegmentButton/types.ts
+++ b/packages/core/src/components/SegmentButton/types.ts
@@ -1,0 +1,6 @@
+import type { SegmentedControlProps } from '@mantine/core';
+
+export interface ISegmentButtonProps extends SegmentedControlProps {
+  size?: 'sm' | 'md' | 'lg';
+  radius?: number | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+}

--- a/packages/core/src/components/Tab/index.tsx
+++ b/packages/core/src/components/Tab/index.tsx
@@ -4,18 +4,7 @@ import { Tabs } from '@mantine/core';
 
 import styles from './styles.module.scss';
 
-import type { TabsProps } from '@mantine/core';
-import type { ReactNode } from 'react';
-
-export interface ITabProps extends TabsProps {
-  tabList: {
-    title: string;
-    value: string;
-    body: ReactNode;
-    icon?: ReactNode;
-  }[];
-  containerPaddingTop?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-}
+import type { ITabProps } from './types';
 
 export const Tab = ({ tabList = [], containerPaddingTop, ...props }: ITabProps) => {
   return (

--- a/packages/core/src/components/Tab/types.ts
+++ b/packages/core/src/components/Tab/types.ts
@@ -1,0 +1,12 @@
+import type { TabsProps } from '@mantine/core';
+import type { ReactNode } from 'react';
+
+export interface ITabProps extends TabsProps {
+  tabList: {
+    title: string;
+    value: string;
+    body: ReactNode;
+    icon?: ReactNode;
+  }[];
+  containerPaddingTop?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+}

--- a/packages/core/src/components/TextField/index.tsx
+++ b/packages/core/src/components/TextField/index.tsx
@@ -6,30 +6,8 @@ import { useCallback, useState } from 'react';
 
 import styles from './styles.module.scss';
 
+import type { ICommonTextFieldProps, TTextFieldProps } from './types';
 import type { InputProps, TextareaProps } from '@mantine/core';
-
-interface ICommonTextFieldProps {
-  label?: string;
-  labelPosition?: 'top' | 'left';
-  size?: 'sm' | 'md' | 'lg';
-  required?: boolean;
-  tooltip?: string;
-  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
-  description?: string;
-  errorMsg?: string;
-  maxTextCount?: number;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-  onClear?: () => void;
-}
-
-export type TTextFieldProps = ICommonTextFieldProps &
-  (
-    | ({ textarea?: false } & Omit<InputProps, keyof ICommonTextFieldProps | 'vars'>)
-    | ({ textarea: true; minRows?: number } & Omit<
-        TextareaProps,
-        keyof ICommonTextFieldProps | 'vars'
-      >)
-  );
 
 const getTextLength = (value: unknown): number => {
   if (typeof value === 'string') {

--- a/packages/core/src/components/TextField/types.ts
+++ b/packages/core/src/components/TextField/types.ts
@@ -1,0 +1,25 @@
+import type { InputProps, TextareaProps } from '@mantine/core';
+import type { ChangeEvent } from 'react';
+
+export interface ICommonTextFieldProps {
+  label?: string;
+  labelPosition?: 'top' | 'left';
+  size?: 'sm' | 'md' | 'lg';
+  required?: boolean;
+  tooltip?: string;
+  tooltipPosition?: 'top' | 'bottom' | 'left' | 'right';
+  description?: string;
+  errorMsg?: string;
+  maxTextCount?: number;
+  onChange?: (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+  onClear?: () => void;
+}
+
+export type TTextFieldProps = ICommonTextFieldProps &
+  (
+    | ({ textarea?: false } & Omit<InputProps, keyof ICommonTextFieldProps | 'vars'>)
+    | ({ textarea: true; minRows?: number } & Omit<
+        TextareaProps,
+        keyof ICommonTextFieldProps | 'vars'
+      >)
+  );

--- a/packages/core/src/components/TimePicker/index.tsx
+++ b/packages/core/src/components/TimePicker/index.tsx
@@ -7,11 +7,7 @@ import { useRef } from 'react';
 
 import styles from './styles.module.scss';
 
-import type { TimeInputProps } from '@mantine/dates';
-
-export interface ITimePickerProps extends TimeInputProps {
-  size?: 'sm' | 'md' | 'lg';
-}
+import type { ITimePickerProps } from './types';
 
 export const TimePicker = ({ size = 'md', ...props }: ITimePickerProps) => {
   const timeInputRef = useRef<HTMLInputElement>(null);

--- a/packages/core/src/components/TimePicker/types.ts
+++ b/packages/core/src/components/TimePicker/types.ts
@@ -1,0 +1,5 @@
+import type { TimeInputProps } from '@mantine/dates';
+
+export interface ITimePickerProps extends TimeInputProps {
+  size?: 'sm' | 'md' | 'lg';
+}

--- a/packages/core/src/components/Toggle/index.tsx
+++ b/packages/core/src/components/Toggle/index.tsx
@@ -5,14 +5,7 @@ import { useCallback, useState } from 'react';
 
 import styles from './styles.module.scss';
 
-import type { SwitchProps } from '@mantine/core';
-
-export interface IToggleProps extends SwitchProps {
-  size?: 'sm' | 'md' | 'lg';
-  labelPosition: 'left' | 'right';
-  disabled?: boolean;
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
-}
+import type { IToggleProps } from './types';
 
 export const Toggle = ({
   size = 'md',

--- a/packages/core/src/components/Toggle/types.ts
+++ b/packages/core/src/components/Toggle/types.ts
@@ -1,0 +1,9 @@
+import type { SwitchProps } from '@mantine/core';
+import type { ChangeEvent } from 'react';
+
+export interface IToggleProps extends SwitchProps {
+  size?: 'sm' | 'md' | 'lg';
+  labelPosition: 'left' | 'right';
+  disabled?: boolean;
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+}

--- a/packages/core/src/components/Tooltip/index.tsx
+++ b/packages/core/src/components/Tooltip/index.tsx
@@ -4,12 +4,7 @@ import { Tooltip as MantineTooltip } from '@mantine/core';
 
 import styles from './styles.module.scss';
 
-import type { TooltipProps as MantineTooltipProps } from '@mantine/core';
-
-export interface ITooltipProps extends MantineTooltipProps {
-  title?: string;
-  content: string;
-}
+import type { ITooltipProps } from './types';
 
 export const Tooltip = ({
   title,

--- a/packages/core/src/components/Tooltip/types.ts
+++ b/packages/core/src/components/Tooltip/types.ts
@@ -1,0 +1,6 @@
+import type { TooltipProps as MantineTooltipProps } from '@mantine/core';
+
+export interface ITooltipProps extends MantineTooltipProps {
+  title?: string;
+  content: string;
+}

--- a/packages/core/src/components/index.ts
+++ b/packages/core/src/components/index.ts
@@ -1,9 +1,14 @@
 export { Button } from './Button';
+export type { IButtonProps, TButtonSize, TButtonVariant } from './Button/types';
+export { BUTTON_SIZES, BUTTON_VARIANTS } from './Button/types';
 export { Checkbox } from './Checkbox';
+export type { ICheckboxProps } from './Checkbox/types';
 export { CalendarDatePicker } from './CalendarDatePicker';
 export type { ICalendarDatePickerProps, TDayOfWeek } from './CalendarDatePicker';
 export { DatePicker } from './DatePicker';
+export type { IDatePickerProps } from './DatePicker/types';
 export { Dropdown } from './Dropdown';
+export type { IDropdownProps } from './Dropdown/types';
 export { ImageInput } from './ImageInput';
 export type {
   TImageInputAccept,
@@ -20,16 +25,27 @@ export type {
   ILottieInputProps,
 } from './LottieInput/types';
 export { Modal } from './Modal';
+export type { IModalProps } from './Modal/types';
 export { Pagination } from './Pagination';
+export type { IPaginationProps } from './Pagination/types';
 export { Radio } from './Radio';
+export type { IRadioProps } from './Radio/types';
 export { SearchBar } from './SearchBar';
+export type { ISearchBarProps } from './SearchBar/types';
 export { SegmentButton } from './SegmentButton';
+export type { ISegmentButtonProps } from './SegmentButton/types';
 export { Tab } from './Tab';
+export type { ITabProps } from './Tab/types';
 export { TextField } from './TextField';
+export type { TTextFieldProps } from './TextField/types';
 export { TimePicker } from './TimePicker';
+export type { ITimePickerProps } from './TimePicker/types';
 export { toast } from './Toast';
+export type { IToastOptions, TToastInput } from './Toast/types';
 export { Toggle } from './Toggle';
+export type { IToggleProps } from './Toggle/types';
 export { Tooltip } from './Tooltip';
+export type { ITooltipProps } from './Tooltip/types';
 
 // Map components
 export {


### PR DESCRIPTION
## 배경

pop-ui "제대로 된 기반" 작업의 첫 하위 프로젝트. 컴포넌트 prop 타입의 **단일 진실원천(single source of truth)** 을 확립한다.

두 가지 구멍을 메움:
- **D — prop 정의 위치 제각각:** 22개 중 13개가 `index.tsx` 인라인 정의였음.
- **B — prop 타입이 barrel에서 안 나감:** `IButtonProps` 포함 ~15개가 미export → 공개 API 반쪽.

## 변경 사항 (6 커밋)

1. **`refactor(core)`** — 단순 10개(Checkbox, Dropdown, Modal, Pagination, Radio, SearchBar, SegmentButton, Tab, TimePicker, Tooltip) 인라인 interface → `types.ts` 이동.
2. **`refactor(core)`** — Toggle: `types.ts` 이동 + `React.ChangeEvent` → named `ChangeEvent`.
3. **`refactor(core)`** — DatePicker(standalone): `types.ts` 이동 + 외부 타입 import 3개 split + `React.ReactNode` → named `ReactNode`.
4. **`refactor(core)`** — TextField(union): `ICommonTextFieldProps` + `TTextFieldProps` 이동 + named `ChangeEvent`. `ICommonTextFieldProps`는 body가 타입 캐스트에 써서 export 유지(barrel엔 미노출).
5. **`feat(core)`** — barrel(`components/index.ts`)에서 15개 컴포넌트 prop 타입 export. 런타임 const(`BUTTON_SIZES` 등)는 값 export로 분리.
6. **`docs`** — CLAUDE.md 컨벤션 박제: prop 타입은 `types.ts`에 정의 + barrel export, union은 `TXxxProps` 유지(레포 eslint가 type alias에 T 강제).

결과: 20개 컴포넌트가 `types.ts` 한 패턴으로 통일.

## 성격

- **런타임 동작 변화 0** — 순수 타입 위치 이동 + 추가 export. 컴포넌트 body 로직·시각 출력 불변.
- **Breaking 아님(minor)** — 기존 export 제거·이름변경 없이 **추가만**. 소비 레포에 새 타입이 공개될 뿐 기존 계약 유지.

## 검증

- `yarn typecheck` (4패키지) ✓
- `yarn build:core` ✓
- 157개 컴포넌트 테스트 통과 ✓ (동작 불변)
- barrel 타입이 `dist/types/components/index.d.ts` 선언에 실제 도달 확인 ✓ (소비자에게 타입 노출됨)

## 참고 (별도 debt, 이번 범위 밖)

- `build` 스크립트가 `vite build`라 `.d.ts`를 직접 emit하지 않음. 현재 `tsc`(=typecheck)가 `declarationDir`로 `dist/types/` 생성. 빌드 파이프라인에서 dts 생성을 명시화하면 더 견고(별도 개선).
- barrel의 `CalendarDatePicker` 타입 export 경로가 `./CalendarDatePicker`(자기 index re-export)로 신규 `./Xxx/types`와 다름 — pre-existing 코스메틱.

🤖 Generated with [Claude Code](https://claude.com/claude-code)