### PR TITLE
refactor(core): 하드코딩 값을 토큰으로 (SCSS px + 정확일치 hex)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ Button, CalendarDatePicker, Checkbox, DatePicker, Dropdown, ImageInput, LottieIn
 
 - 숫자 radius는 매직넘버 대신 `@pop-ui/foundation`의 `BorderRadiusXXX` 상수를 쓴다: `BorderRadius0=0, 50=2, 100=4, 150=6, 200=8, 300=12, 400=16, 500=20, 1000=9999`(px 숫자).
 - 색상도 하드코딩 대신 `ColorGray600` 같은 foundation 상수.
-- 토큰은 `packages/foundation/token.json`이 원본, `config.js`(style-dictionary)가 SCSS 변수와 JS 상수를 생성. **생성 파일(`src/tokens/*.ts`)은 직접 편집 금지**, `yarn token-build`로 재생성.
+- **SCSS에서 px 직접값 대신 함수를 쓴다**: `fn.spacing($step)`(패딩/마진/gap/폭/높이), `fn.font-size($step)`(글꼴 크기), `fn.border-width($step)`(선/아웃라인 두께). `@use "../shared/functions" as fn;` 후 `padding: fn.spacing(400)`(=16px). 스텝→값은 산술이 아니라 lookup(예: `border-width(37)`=1.5px, `font-size(450)`=14px) — 함수가 잘못된 스텝에 `@error`를 낸다. 스케일에 없는 값(예: `13px`, `30px`)은 px 그대로 둔다.
+- 토큰은 `packages/foundation/token.json`이 원본, `config.js`(style-dictionary)가 SCSS 변수·map과 JS 상수를 생성. **생성 파일(`src/tokens/*.ts`, `shared/_*-map.scss`)은 직접 편집 금지**, `yarn token-build`로 재생성. `shared/_functions.scss`는 그 map을 px로 변환하는 수동 파일.
 
 ## 신규 컴포넌트 체크리스트
 
@@ -77,7 +78,7 @@ Button, CalendarDatePicker, Checkbox, DatePicker, Dropdown, ImageInput, LottieIn
 3. Props는 `IXxxProps`(interface), union은 `TXxx`. 타입은 **반드시 `types.ts`에** 정의하고 **barrel에서 export**(`export type { IXxxProps } from './Xxx/types'`).
 4. `size` 노출 시 `sm|md|lg` 3단계. 폭 같은 다른 의미면 그 사실을 주석/문서에 명시.
 5. 자체 boolean은 `is*`, 상속 boolean은 그대로.
-6. 숫자 radius/색상은 foundation 토큰 상수 사용.
+6. 숫자 radius/색상은 foundation 토큰 상수 사용. SCSS의 px는 `fn.spacing()`/`fn.font-size()`/`fn.border-width()` 함수(스케일에 없는 값만 raw px).
 
 ## 검증
 

--- a/packages/core/src/components/Button/styles.module.scss
+++ b/packages/core/src/components/Button/styles.module.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 @function button-font-weight($weight-token) {
   @if $weight-token == Bold {
@@ -41,7 +42,7 @@
 @mixin ButtonVariant($bg, $text, $border-color: transparent) {
   background-color: $bg;
   color: $text;
-  border: 1px solid $border-color;
+  border: fn.border-width(25) solid $border-color;
 }
 
 $button-size-layout-map: (
@@ -385,7 +386,7 @@ $button-variant-class-map: (
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--button-section-gap, 6px);
+  gap: var(--button-section-gap, fn.spacing(150));
   width: 100%;
 }
 
@@ -393,7 +394,7 @@ $button-variant-class-map: (
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: fn.spacing(150);
   white-space: nowrap;
 }
 

--- a/packages/core/src/components/CalendarDatePicker/CalendarDatePicker.stories.tsx
+++ b/packages/core/src/components/CalendarDatePicker/CalendarDatePicker.stories.tsx
@@ -261,10 +261,10 @@ export const BehaviorPreserved_CustomClassNameMerging: StoryObj<typeof CalendarD
   args: {
     type: 'range',
     highlightToday: false,
-    className: customStyles.customWrapper,
+    className: customStyles.Custom__Wrapper,
     classNames: {
-      day: customStyles.customDay,
-      weekday: customStyles.customWeekday,
+      day: customStyles.Custom__Day,
+      weekday: customStyles.Custom__Weekday,
     },
   },
   parameters: {

--- a/packages/core/src/components/CalendarDatePicker/CustomStyles.module.scss
+++ b/packages/core/src/components/CalendarDatePicker/CustomStyles.module.scss
@@ -1,18 +1,21 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 // 커스텀 클래스 병합 스토리북용 스타일
-.customWrapper {
-  padding: 24px;
+.Custom__Wrapper {
+  padding: fn.spacing(600);
 }
-.customWeekday,
-.customDay {
+
+.Custom__Weekday,
+.Custom__Day {
   font-weight: 700;
 }
 
-.customWeekday {
+.Custom__Weekday {
   color: $color-blue-400;
 }
-.customDay {
+
+.Custom__Day {
   &:hover {
     background-color: $color-blue-100;
   }
@@ -20,6 +23,7 @@
   &[data-today][data-highlight-today] {
     color: $color-blue-500;
   }
+
   &[data-weekend] {
     color: $color-blue-400;
   }

--- a/packages/core/src/components/Checkbox/styles.module.scss
+++ b/packages/core/src/components/Checkbox/styles.module.scss
@@ -1,10 +1,11 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 @mixin CheckboxColor {
   &:hover {
     background-color: $color-aqua-50;
     border-color: $color-aqua-300;
-    border-width: 2px;
+    border-width: fn.border-width(50);
   }
 
   &:checked {
@@ -15,7 +16,7 @@
   &:disabled {
     background-color: $color-gray-100;
     border-color: $color-gray-200;
-    border-width: 2px;
+    border-width: fn.border-width(50);
   }
 }
 
@@ -31,7 +32,7 @@
     height: 18px;
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-style: normal;
     font-weight: 500;
     display: flex;
@@ -41,7 +42,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 12px;
+    font-size: fn.font-size(400);
     font-style: normal;
     font-weight: 500;
   }
@@ -51,15 +52,15 @@
   input {
     @include CheckboxColor;
 
-    width: 24px;
-    height: 24px;
+    width: fn.spacing(600);
+    height: fn.spacing(600);
   }
 
   label {
-    height: 24px;
+    height: fn.spacing(600);
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 18px;
+    font-size: fn.font-size(550);
     font-style: normal;
     font-weight: 600;
     display: flex;
@@ -69,7 +70,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 14px;
+    font-size: fn.font-size(450);
     font-style: normal;
     font-weight: 500;
   }
@@ -79,15 +80,15 @@
   input {
     @include CheckboxColor;
 
-    width: 32px;
-    height: 32px;
+    width: fn.spacing(800);
+    height: fn.spacing(800);
   }
 
   label {
-    height: 32px;
+    height: fn.spacing(800);
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 24px;
+    font-size: fn.font-size(700);
     font-style: normal;
     font-weight: 700;
     display: flex;
@@ -97,7 +98,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-style: normal;
     font-weight: 500;
   }

--- a/packages/core/src/components/DatePicker/styles.module.scss
+++ b/packages/core/src/components/DatePicker/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 @mixin DatePickerShellFocus {
   &:hover {
@@ -25,7 +26,7 @@
 }
 
 .DatePickerBase {
-  --date-picker-height: 44px;
+  --date-picker-height: #{fn.spacing(1100)};
   --date-picker-padding-inline: #{$spacing-300}px;
   --date-picker-font-size: #{$font-size-450}px;
   --date-picker-line-height: #{$lh-500};
@@ -33,7 +34,7 @@
   --date-picker-section-width: 42px;
   --date-picker-icon-shell-size: #{$spacing-800}px;
   --date-picker-popup-radius: #{$border-radius-300};
-  --date-picker-time-control-height: 44px;
+  --date-picker-time-control-height: #{fn.spacing(1100)};
   --date-picker-time-control-radius: #{$border-radius-200};
 }
 
@@ -42,33 +43,33 @@
 }
 
 .DatePicker--Small {
-  --date-picker-height: 32px;
+  --date-picker-height: #{fn.spacing(800)};
   --date-picker-padding-inline: #{$spacing-200}px;
   --date-picker-font-size: #{$font-size-450}px;
   --date-picker-radius: #{$border-radius-200};
   --date-picker-section-width: 34px;
-  --date-picker-icon-shell-size: 24px;
-  --date-picker-time-control-height: 32px;
+  --date-picker-icon-shell-size: #{fn.spacing(600)};
+  --date-picker-time-control-height: #{fn.spacing(800)};
 }
 
 .DatePicker--Medium {
-  --date-picker-height: 44px;
+  --date-picker-height: #{fn.spacing(1100)};
   --date-picker-padding-inline: #{$spacing-300}px;
   --date-picker-font-size: #{$font-size-450}px;
   --date-picker-radius: #{$border-radius-300};
   --date-picker-section-width: 42px;
   --date-picker-icon-shell-size: #{$spacing-800}px;
-  --date-picker-time-control-height: 44px;
+  --date-picker-time-control-height: #{fn.spacing(1100)};
 }
 
 .DatePicker--Large {
-  --date-picker-height: 52px;
+  --date-picker-height: #{fn.spacing(1300)};
   --date-picker-padding-inline: #{$spacing-400}px;
   --date-picker-font-size: #{$font-size-500}px;
   --date-picker-radius: #{$border-radius-300};
   --date-picker-section-width: 50px;
-  --date-picker-icon-shell-size: 36px;
-  --date-picker-time-control-height: 52px;
+  --date-picker-icon-shell-size: #{fn.spacing(900)};
+  --date-picker-time-control-height: #{fn.spacing(1300)};
 }
 
 .DatePicker__Wrapper {

--- a/packages/core/src/components/Dropdown/index.tsx
+++ b/packages/core/src/components/Dropdown/index.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { Input, Select, Tooltip } from '@mantine/core';
-import { IconInfoCircle, IconChevronUp, IconChevronDown } from '@pop-ui/foundation';
+import {
+  ColorBlack,
+  ColorGray100,
+  IconInfoCircle,
+  IconChevronUp,
+  IconChevronDown,
+} from '@pop-ui/foundation';
 import { useState } from 'react';
 
 import styles from './styles.module.scss';
@@ -73,8 +79,8 @@ export const Dropdown = ({
             option: {
               '&[data-selected]': {
                 '&, &:hover': {
-                  backgroundColor: '#e7e7e7',
-                  color: '#000000',
+                  backgroundColor: ColorGray100,
+                  color: ColorBlack,
                 } as CSSProperties,
               } as CSSProperties,
             } as CSSProperties,

--- a/packages/core/src/components/Dropdown/styles.module.scss
+++ b/packages/core/src/components/Dropdown/styles.module.scss
@@ -1,9 +1,10 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 .Dropdown--LeftLabel {
   display: flex;
   flex-direction: row;
-  gap: 20px;
+  gap: fn.spacing(500);
 }
 
 .Dropdown--TopLabel {
@@ -13,29 +14,29 @@
 
 .Dropdown__Label--Small {
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 8px 3px;
+  margin: fn.spacing(200) 3px;
 }
 
 .Dropdown__Label--Medium {
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: fn.font-size(500);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 12px 4px;
+  margin: fn.spacing(300) fn.spacing(100);
 }
 
 .Dropdown__Label--Large {
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: fn.font-size(550);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 16px 4px;
+  margin: fn.spacing(400) fn.spacing(100);
 }
 
 .Dropdown__Tooltip--Small {
@@ -44,8 +45,8 @@
 }
 
 .Dropdown__Tooltip--Medium {
-  width: 16px;
-  height: 16px;
+  width: fn.spacing(400);
+  height: fn.spacing(400);
 }
 
 .Dropdown__Tooltip--Large {
@@ -55,12 +56,12 @@
 
 @mixin DropdownBorderFocus {
   &:hover {
-    outline: 1.5px solid $color-aqua-300;
+    outline: fn.border-width(37) solid $color-aqua-300;
     border-color: transparent;
   }
 
   &:focus-within {
-    outline: 1.5px solid $color-aqua-500;
+    outline: fn.border-width(37) solid $color-aqua-500;
     border-color: transparent;
   }
 }
@@ -68,8 +69,8 @@
 .Dropdown--Small {
   input {
     height: 30px;
-    padding: 8px;
-    font-size: 14px;
+    padding: fn.spacing(200);
+    font-size: fn.font-size(450);
     min-height: 30px;
 
     @include DropdownBorderFocus;
@@ -78,10 +79,10 @@
 
 .Dropdown--Medium {
   input {
-    height: 40px;
-    padding: 12px;
-    font-size: 14px;
-    min-height: 40px;
+    height: fn.spacing(1000);
+    padding: fn.spacing(300);
+    font-size: fn.font-size(450);
+    min-height: fn.spacing(1000);
 
     @include DropdownBorderFocus;
   }
@@ -90,8 +91,8 @@
 .Dropdown--Large {
   input {
     height: 50px;
-    padding: 16px;
-    font-size: 16px;
+    padding: fn.spacing(400);
+    font-size: fn.font-size(500);
     min-height: 50px;
 
     @include DropdownBorderFocus;
@@ -99,9 +100,9 @@
 }
 
 .Dropdown__Description {
-  margin-top: 8px;
+  margin-top: fn.spacing(200);
 }
 
 .Dropdown__ErrorMsg {
-  margin-top: 4px;
+  margin-top: fn.spacing(100);
 }

--- a/packages/core/src/components/ImageInput/ImageInput.test.tsx
+++ b/packages/core/src/components/ImageInput/ImageInput.test.tsx
@@ -77,6 +77,10 @@ vi.mock('@pop-ui/foundation', () => ({
   IconPhoto: () => <div data-testid="icon-photo" />,
   IconXCircle: () => <div data-testid="icon-xcircle" />,
   IconDragMenu: () => <div data-testid="icon-drag" />,
+  ColorRed700: '#e03131',
+  ColorAqua700: '#07a3c6',
+  ColorAqua500: '#0fd3d8',
+  ColorGray600: '#808080',
 }));
 
 vi.mock('../Button', () => ({

--- a/packages/core/src/components/ImageInput/ImageInputCropModal.tsx
+++ b/packages/core/src/components/ImageInput/ImageInputCropModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Group, Stack } from '@mantine/core';
+import { ColorWhite } from '@pop-ui/foundation';
 import { useState } from 'react';
 import Cropper from 'react-easy-crop';
 
@@ -98,7 +99,7 @@ export function ImageInputCropModal({
       withCloseButton
     >
       <Stack>
-        <div style={{ position: 'relative', height: 320, background: '#fff' }}>
+        <div style={{ position: 'relative', height: 320, background: ColorWhite }}>
           <Cropper
             image={item?.url ?? ''}
             crop={crop}
@@ -110,7 +111,7 @@ export function ImageInputCropModal({
             onCropChange={setCrop}
             onZoomChange={setZoom}
             onCropComplete={(_, pixels) => setCroppedAreaPixels(pixels)}
-            style={{ containerStyle: { backgroundColor: '#ffffff' } }}
+            style={{ containerStyle: { backgroundColor: ColorWhite } }}
           />
         </div>
         <Group justify="flex-end" style={{ padding: '0 16px' }}>

--- a/packages/core/src/components/ImageInput/index.tsx
+++ b/packages/core/src/components/ImageInput/index.tsx
@@ -4,7 +4,7 @@ import { DndContext, closestCenter } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { Input } from '@mantine/core';
 import { IMAGE_MIME_TYPE } from '@mantine/dropzone';
-import { IconPhoto } from '@pop-ui/foundation';
+import { ColorAqua700, ColorRed700, IconPhoto } from '@pop-ui/foundation';
 import { useEffect, useRef, useState } from 'react';
 
 import { Button } from '../Button';
@@ -278,7 +278,9 @@ export const ImageInput = ({
                         width={width}
                         height={height}
                       >
-                        {hasIcon && <IconPhoto size={36} color={isError ? '#e03131' : '#07a3c6'} />}
+                        {hasIcon && (
+                          <IconPhoto size={36} color={isError ? ColorRed700 : ColorAqua700} />
+                        )}
                         {placeholder && (
                           <div
                             className={`${styles.PlaceholderText}${isError ? ` ${styles.PlaceholderTextError}` : ''}`}
@@ -326,7 +328,9 @@ export const ImageInput = ({
                       width={width}
                       height={height}
                     >
-                      {hasIcon && <IconPhoto size={36} color={isError ? '#e03131' : '#07a3c6'} />}
+                      {hasIcon && (
+                        <IconPhoto size={36} color={isError ? ColorRed700 : ColorAqua700} />
+                      )}
                       {placeholder && (
                         <div
                           className={`${styles.PlaceholderText}${isError ? ` ${styles.PlaceholderTextError}` : ''}`}

--- a/packages/core/src/components/ImageInput/styles.module.scss
+++ b/packages/core/src/components/ImageInput/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 .Container {
   display: flex;
@@ -18,10 +19,10 @@
 // 편집 버튼 (ImageInput 전용)
 .EditButton {
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: fn.font-size(400);
   border-radius: 8px;
-  height: 24px;
-  padding: 0 8px;
+  height: fn.spacing(600);
+  padding: 0 fn.spacing(200);
 }
 
 // PlaceholderText는 shared Dropzone children으로 사용 (ImageInput에서 className으로 전달)
@@ -34,7 +35,7 @@
 
   span {
     color: $color-aqua-700;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-weight: 500;
     line-height: 1.4;
   }

--- a/packages/core/src/components/LottieInput/LottieInput.test.tsx
+++ b/packages/core/src/components/LottieInput/LottieInput.test.tsx
@@ -79,7 +79,10 @@ vi.mock('@pop-ui/foundation', () => ({
   IconPhoto: () => <div data-testid="icon-photo" />,
   IconXCircle: () => <div data-testid="icon-xcircle" />,
   IconDragMenu: () => <div data-testid="icon-drag" />,
-  ColorAqua500: '#07a3c6',
+  ColorRed700: '#e03131',
+  ColorAqua700: '#07a3c6',
+  ColorAqua500: '#0fd3d8',
+  ColorGray600: '#808080',
 }));
 
 vi.mock('lottie-react', () => ({

--- a/packages/core/src/components/LottieInput/index.tsx
+++ b/packages/core/src/components/LottieInput/index.tsx
@@ -3,7 +3,7 @@
 import { DndContext, closestCenter } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
 import { Input } from '@mantine/core';
-import { IconPhoto } from '@pop-ui/foundation';
+import { ColorAqua700, ColorRed700, IconPhoto } from '@pop-ui/foundation';
 import Lottie from 'lottie-react';
 import { useEffect, useState } from 'react';
 
@@ -276,7 +276,9 @@ export const LottieInput = ({
                         width={width}
                         height={height}
                       >
-                        {hasIcon && <IconPhoto size={36} color={isError ? '#e03131' : '#07a3c6'} />}
+                        {hasIcon && (
+                          <IconPhoto size={36} color={isError ? ColorRed700 : ColorAqua700} />
+                        )}
                         {placeholder && (
                           <div
                             className={`${styles.PlaceholderText}${isError ? ` ${styles.PlaceholderTextError}` : ''}`}
@@ -319,7 +321,9 @@ export const LottieInput = ({
                       width={width}
                       height={height}
                     >
-                      {hasIcon && <IconPhoto size={36} color={isError ? '#e03131' : '#07a3c6'} />}
+                      {hasIcon && (
+                        <IconPhoto size={36} color={isError ? ColorRed700 : ColorAqua700} />
+                      )}
                       {placeholder && (
                         <div
                           className={`${styles.PlaceholderText}${isError ? ` ${styles.PlaceholderTextError}` : ''}`}

--- a/packages/core/src/components/LottieInput/styles.module.scss
+++ b/packages/core/src/components/LottieInput/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 .Container {
   display: flex;
@@ -28,7 +29,7 @@
 
   span {
     color: $color-aqua-700;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-weight: 500;
     line-height: 1.4;
   }

--- a/packages/core/src/components/MapInfo/styles.module.scss
+++ b/packages/core/src/components/MapInfo/styles.module.scss
@@ -1,9 +1,10 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 .MapInfo {
   overflow: hidden;
   border-radius: 10px;
-  border: 1px solid $color-gray-100;
+  border: fn.border-width(25) solid $color-gray-100;
   background: $color-white;
 
   &__NoClientId {
@@ -11,8 +12,8 @@
     align-items: center;
     justify-content: center;
     height: 100%;
-    padding: 16px;
-    font-size: 14px;
+    padding: fn.spacing(400);
+    font-size: fn.font-size(450);
     color: $color-gray-500;
     text-align: center;
   }
@@ -25,15 +26,15 @@
   &__ExpandButton {
     position: absolute;
     z-index: 10;
-    top: 8px;
-    right: 8px;
+    top: fn.spacing(200);
+    right: fn.spacing(200);
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 36px;
-    height: 36px;
+    width: fn.spacing(900);
+    height: fn.spacing(900);
     background: $color-white;
-    border: 1px solid $color-gray-100;
+    border: fn.border-width(25) solid $color-gray-100;
     border-radius: 50%;
     cursor: pointer;
     transition: background-color 0.2s;
@@ -48,10 +49,10 @@
     justify-content: space-between;
     align-items: center;
     width: 100%;
-    height: 60px;
-    padding: 4px 8px;
+    height: fn.spacing(1500);
+    padding: fn.spacing(100) fn.spacing(200);
     background: $color-white;
-    border-top: 1px solid $color-gray-100;
+    border-top: fn.border-width(25) solid $color-gray-100;
   }
 
   &__AddressContent {
@@ -63,7 +64,7 @@
   }
 
   &__Address {
-    font-size: 14px;
+    font-size: fn.font-size(450);
     line-height: 1.4;
     color: $color-gray-800;
     cursor: pointer;
@@ -89,13 +90,13 @@
   &__DirectionButton {
     min-height: fit-content !important;
     height: fit-content !important;
-    padding: 8px 12px !important;
+    padding: fn.spacing(200) fn.spacing(300) !important;
     border-radius: 99px !important;
-    font-size: 14px !important;
+    font-size: fn.font-size(450) !important;
     font-weight: 600 !important;
     background: $color-white !important;
     color: $color-gray-800 !important;
-    border: 1px solid $color-gray-100 !important;
+    border: fn.border-width(25) solid $color-gray-100 !important;
 
     &:hover {
       background: $color-gray-50 !important;

--- a/packages/core/src/components/Pagination/style.module.scss
+++ b/packages/core/src/components/Pagination/style.module.scss
@@ -1,16 +1,17 @@
 @use '../shared/variables.scss' as *;
 @use '../shared/font.css' as *;
+@use '../shared/functions' as fn;
 
 @mixin NumberBox {
   display: flex;
   align-items: center;
   justify-content: center;
-  min-width: 40px;
-  height: 40px;
+  min-width: fn.spacing(1000);
+  height: fn.spacing(1000);
   border-radius: 8px;
   gap: 10px;
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-weight: 400;
   letter-spacing: 0;
   text-align: center;
@@ -52,9 +53,9 @@
 .Pagination__Arrow {
   @include NumberBox;
 
-  border: 1px solid $color-gray-400;
-  margin: 0 8px;
-  width: 40px;
-  height: 40px;
+  border: fn.border-width(25) solid $color-gray-400;
+  margin: 0 fn.spacing(200);
+  width: fn.spacing(1000);
+  height: fn.spacing(1000);
   background-color: $color-white;
 }

--- a/packages/core/src/components/Radio/styles.module.scss
+++ b/packages/core/src/components/Radio/styles.module.scss
@@ -1,25 +1,26 @@
 @use 'sass:map';
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 $radio-config-small: (
   size: 18px,
-  label-font-size: 16px,
+  label-font-size: fn.font-size(500),
   label-font-weight: 500,
-  description-font-size: 12px,
+  description-font-size: fn.font-size(400),
   description-font-weight: 500,
 );
 $radio-config-medium: (
-  size: 24px,
-  label-font-size: 18px,
+  size: fn.spacing(600),
+  label-font-size: fn.font-size(550),
   label-font-weight: 600,
-  description-font-size: 14px,
+  description-font-size: fn.font-size(450),
   description-font-weight: 500,
 );
 $radio-config-large: (
-  size: 32px,
-  label-font-size: 24px,
+  size: fn.spacing(800),
+  label-font-size: fn.font-size(700),
   label-font-weight: 700,
-  description-font-size: 16px,
+  description-font-size: fn.font-size(500),
   description-font-weight: 500,
 );
 
@@ -32,7 +33,7 @@ $radio-config-large: (
   &:hover {
     background-color: $color-aqua-50;
     border-color: $color-aqua-300;
-    border-width: 2px;
+    border-width: fn.border-width(50);
   }
 
   &:checked {
@@ -43,7 +44,7 @@ $radio-config-large: (
   &:disabled {
     background-color: $color-gray-100;
     border-color: $color-gray-200;
-    border-width: 2px;
+    border-width: fn.border-width(50);
   }
 }
 

--- a/packages/core/src/components/SearchBar/styles.module.scss
+++ b/packages/core/src/components/SearchBar/styles.module.scss
@@ -1,9 +1,10 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 .SearchBar--LeftLabel {
   display: flex;
   flex-direction: row;
-  gap: 20px;
+  gap: fn.spacing(500);
 }
 
 .SearchBar--TopLabel {
@@ -13,29 +14,29 @@
 
 .SearchBar__Label--Small {
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 8px 3px;
+  margin: fn.spacing(200) 3px;
 }
 
 .SearchBar__Label--Medium {
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: fn.font-size(500);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 12px 4px;
+  margin: fn.spacing(300) fn.spacing(100);
 }
 
 .SearchBar__Label--Large {
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: fn.font-size(550);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 16px 4px;
+  margin: fn.spacing(400) fn.spacing(100);
 }
 
 .SearchBar__Tooltip--Small {
@@ -44,8 +45,8 @@
 }
 
 .SearchBar__Tooltip--Medium {
-  width: 16px;
-  height: 16px;
+  width: fn.spacing(400);
+  height: fn.spacing(400);
 }
 
 .SearchBar__Tooltip--Large {
@@ -55,12 +56,12 @@
 
 @mixin SearchBarBorderFocus {
   &:hover {
-    outline: 1.5px solid $color-aqua-300;
+    outline: fn.border-width(37) solid $color-aqua-300;
     border-color: transparent;
   }
 
   &:focus-within {
-    outline: 1.5px solid $color-aqua-500;
+    outline: fn.border-width(37) solid $color-aqua-500;
     border-color: transparent;
   }
 }
@@ -74,7 +75,7 @@
   bottom: -16px;
   right: 0;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: fn.font-size(400);
   font-weight: 500;
   letter-spacing: 0;
   text-align: right;
@@ -91,8 +92,8 @@
   input {
     height: 30px;
     min-height: 30px;
-    padding: 8px;
-    font-size: 14px;
+    padding: fn.spacing(200);
+    font-size: fn.font-size(450);
 
     @include SearchBarBorderFocus;
   }
@@ -100,10 +101,10 @@
 
 .SearchBar--Medium {
   input {
-    height: 40px;
-    min-height: 40px;
-    padding: 12px;
-    font-size: 14px;
+    height: fn.spacing(1000);
+    min-height: fn.spacing(1000);
+    padding: fn.spacing(300);
+    font-size: fn.font-size(450);
 
     @include SearchBarBorderFocus;
   }
@@ -113,19 +114,19 @@
   input {
     height: 50px;
     min-height: 50px;
-    padding: 16px;
-    font-size: 16px;
+    padding: fn.spacing(400);
+    font-size: fn.font-size(500);
 
     @include SearchBarBorderFocus;
   }
 }
 
 .SearchBar__Description {
-  margin-top: 8px;
+  margin-top: fn.spacing(200);
 }
 
 .SearchBar__ErrorMsg {
-  margin-top: 4px;
+  margin-top: fn.spacing(100);
 }
 
 .SearchBar__ClearButton {

--- a/packages/core/src/components/SegmentButton/styles.module.scss
+++ b/packages/core/src/components/SegmentButton/styles.module.scss
@@ -1,4 +1,5 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 @mixin SegmentButtonLabel {
   box-sizing: border-box;
@@ -16,8 +17,8 @@
     @include SegmentButtonLabel;
 
     height: 30px;
-    padding: 0 8px;
-    font-size: 14px;
+    padding: 0 fn.spacing(200);
+    font-size: fn.font-size(450);
   }
 }
 
@@ -25,9 +26,9 @@
   label {
     @include SegmentButtonLabel;
 
-    height: 40px;
-    padding: 0 12px;
-    font-size: 14px;
+    height: fn.spacing(1000);
+    padding: 0 fn.spacing(300);
+    font-size: fn.font-size(450);
   }
 }
 
@@ -36,7 +37,7 @@
     @include SegmentButtonLabel;
 
     height: 50px;
-    padding: 0 16px;
-    font-size: 16px;
+    padding: 0 fn.spacing(400);
+    font-size: fn.font-size(500);
   }
 }

--- a/packages/core/src/components/Tab/styles.module.scss
+++ b/packages/core/src/components/Tab/styles.module.scss
@@ -1,7 +1,8 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 .Tab__TitleList {
-  border-bottom: 2px solid $color-gray-100;
+  border-bottom: fn.border-width(50) solid $color-gray-100;
 
   button {
     margin-bottom: 7px;
@@ -9,14 +10,14 @@
     align-items: center;
     text-align: center;
     font-family: Pretendard;
-    font-size: 18px;
+    font-size: fn.font-size(550);
     font-style: normal;
     font-weight: 700;
     height: 50px;
     color: $color-gray-400;
     border-radius: 6px;
     border: none;
-    padding: 0 20px;
+    padding: 0 fn.spacing(500);
     cursor: pointer;
 
     &:hover {
@@ -39,7 +40,7 @@
         bottom: -9px;
         left: 0;
         width: 100%;
-        border-bottom: 2px solid $color-aqua-600;
+        border-bottom: fn.border-width(50) solid $color-aqua-600;
         border-color: $color-aqua-600;
       }
     }

--- a/packages/core/src/components/TextField/styles.module.scss
+++ b/packages/core/src/components/TextField/styles.module.scss
@@ -1,9 +1,10 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 .TextField--LeftLabel {
   display: flex;
   flex-direction: row;
-  gap: 20px;
+  gap: fn.spacing(500);
 }
 
 .TextField--TopLabel {
@@ -13,29 +14,29 @@
 
 .TextField__Label--Small {
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 8px 3px;
+  margin: fn.spacing(200) 3px;
 }
 
 .TextField__Label--Medium {
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: fn.font-size(500);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 12px 4px;
+  margin: fn.spacing(300) fn.spacing(100);
 }
 
 .TextField__Label--Large {
   font-family: Pretendard;
-  font-size: 18px;
+  font-size: fn.font-size(550);
   font-weight: 600;
   letter-spacing: 0;
   text-align: left;
-  margin: 16px 4px;
+  margin: fn.spacing(400) fn.spacing(100);
 }
 
 .TextField__Tooltip--Small {
@@ -44,8 +45,8 @@
 }
 
 .TextField__Tooltip--Medium {
-  width: 16px;
-  height: 16px;
+  width: fn.spacing(400);
+  height: fn.spacing(400);
 }
 
 .TextField__Tooltip--Large {
@@ -55,12 +56,12 @@
 
 @mixin BorderFocus {
   &:hover {
-    outline: 1.5px solid $color-aqua-300;
+    outline: fn.border-width(37) solid $color-aqua-300;
     border-color: transparent;
   }
 
   &:focus-within {
-    outline: 1.5px solid $color-aqua-500;
+    outline: fn.border-width(37) solid $color-aqua-500;
     border-color: transparent;
   }
 }
@@ -74,7 +75,7 @@
   bottom: -16px;
   right: 0;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: fn.font-size(400);
   font-weight: 500;
   letter-spacing: 0;
   text-align: right;
@@ -91,8 +92,8 @@
   input {
     height: 30px;
     min-height: 30px;
-    padding: 8px;
-    font-size: 14px;
+    padding: fn.spacing(200);
+    font-size: fn.font-size(450);
 
     @include BorderFocus;
   }
@@ -100,10 +101,10 @@
 
 .TextField--Medium {
   input {
-    height: 40px;
-    min-height: 40px;
-    padding: 12px;
-    font-size: 14px;
+    height: fn.spacing(1000);
+    min-height: fn.spacing(1000);
+    padding: fn.spacing(300);
+    font-size: fn.font-size(450);
 
     @include BorderFocus;
   }
@@ -113,19 +114,19 @@
   input {
     height: 50px;
     min-height: 50px;
-    padding: 16px;
-    font-size: 16px;
+    padding: fn.spacing(400);
+    font-size: fn.font-size(500);
 
     @include BorderFocus;
   }
 }
 
 .TextField__Description {
-  margin-top: 8px;
+  margin-top: fn.spacing(200);
 }
 
 .TextField__ErrorMsg {
-  margin-top: 4px;
+  margin-top: fn.spacing(100);
 }
 
 .TextField__ClearButton {

--- a/packages/core/src/components/TimePicker/styles.module.scss
+++ b/packages/core/src/components/TimePicker/styles.module.scss
@@ -1,25 +1,26 @@
 @use 'sass:map';
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 $time-picker-config-small: (
   height: 30px,
   min-height: 30px,
-  padding: 8px,
-  font-size: 14px,
+  padding: fn.spacing(200),
+  font-size: fn.font-size(450),
   line-height: 100%,
 );
 $time-picker-config-medium: (
-  height: 40px,
-  min-height: 40px,
-  padding: 12px,
-  font-size: 14px,
+  height: fn.spacing(1000),
+  min-height: fn.spacing(1000),
+  padding: fn.spacing(300),
+  font-size: fn.font-size(450),
   line-height: 100%,
 );
 $time-picker-config-large: (
   height: 50px,
   min-height: 50px,
-  padding: 16px,
-  font-size: 16px,
+  padding: fn.spacing(400),
+  font-size: fn.font-size(500),
   line-height: 100%,
 );
 
@@ -33,13 +34,13 @@ $time-picker-config-large: (
 
 @mixin TimePickerFocus {
   &:hover {
-    outline: 1.5px solid $color-aqua-300;
+    outline: fn.border-width(37) solid $color-aqua-300;
     border-color: transparent;
     background-color: $color-white;
   }
 
   &:focus-within {
-    outline: 1.5px solid $color-aqua-500;
+    outline: fn.border-width(37) solid $color-aqua-500;
     border-color: transparent;
   }
 }

--- a/packages/core/src/components/Toast/styles.module.scss
+++ b/packages/core/src/components/Toast/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 /* stylelint-disable selector-class-pattern */
 :global {
@@ -29,8 +30,8 @@
   background-color: rgb(0 0 0 / 60%);
   border-radius: 16px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 8%);
-  height: 48px;
-  padding: 0 20px;
+  height: fn.spacing(1200);
+  padding: 0 fn.spacing(500);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -38,7 +39,7 @@
   max-width: max-content;
   border: none !important;
   border-left: none !important;
-  margin: 12px !important;
+  margin: fn.spacing(300) !important;
 
   &::before {
     display: none !important;
@@ -51,7 +52,7 @@
   border-radius: 0 !important;
   width: auto !important;
   height: auto !important;
-  margin-right: 8px !important;
+  margin-right: fn.spacing(200) !important;
   padding: 0 !important;
 }
 
@@ -67,7 +68,7 @@
 .Toast__Message {
   color: $color-white;
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-weight: 700;
   text-align: center;
   line-height: 150%;

--- a/packages/core/src/components/Toggle/index.tsx
+++ b/packages/core/src/components/Toggle/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Switch } from '@mantine/core';
+import { ColorAqua500 } from '@pop-ui/foundation';
 import { useCallback, useState } from 'react';
 
 import styles from './styles.module.scss';
@@ -45,8 +46,8 @@ export const Toggle = ({
       onChange={onChangeHandler}
       styles={() => ({
         track: {
-          backgroundColor: !disabled && isChecked ? '#0fd3d8 !important' : undefined,
-          borderColor: !disabled && isChecked ? '#0fd3d8 !important' : undefined,
+          backgroundColor: !disabled && isChecked ? `${ColorAqua500} !important` : undefined,
+          borderColor: !disabled && isChecked ? `${ColorAqua500} !important` : undefined,
           width: trackWidth,
         },
       })}

--- a/packages/core/src/components/Toggle/styles.module.scss
+++ b/packages/core/src/components/Toggle/styles.module.scss
@@ -1,11 +1,12 @@
 @use "../shared/variables.scss" as *;
+@use "../shared/functions" as fn;
 
 .Toggle--Small {
   label {
     height: 18px;
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-style: normal;
     font-weight: 500;
     display: flex;
@@ -15,7 +16,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 12px;
+    font-size: fn.font-size(400);
     font-style: normal;
     font-weight: 500;
   }
@@ -23,10 +24,10 @@
 
 .Toggle--Medium {
   label {
-    height: 24px;
+    height: fn.spacing(600);
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 18px;
+    font-size: fn.font-size(550);
     font-style: normal;
     font-weight: 600;
     display: flex;
@@ -36,7 +37,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 14px;
+    font-size: fn.font-size(450);
     font-style: normal;
     font-weight: 500;
   }
@@ -44,10 +45,10 @@
 
 .Toggle--Large {
   label {
-    height: 32px;
+    height: fn.spacing(800);
     color: $color-gray-900;
     font-family: Pretendard;
-    font-size: 24px;
+    font-size: fn.font-size(700);
     font-style: normal;
     font-weight: 700;
     display: flex;
@@ -57,7 +58,7 @@
   div {
     color: $color-gray-600;
     font-family: Pretendard;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-style: normal;
     font-weight: 500;
   }

--- a/packages/core/src/components/Tooltip/styles.module.scss
+++ b/packages/core/src/components/Tooltip/styles.module.scss
@@ -1,8 +1,9 @@
 @use '../shared/variables.scss' as *;
+@use '../shared/functions' as fn;
 
 @mixin TooltipText {
   font-family: Pretendard;
-  font-size: 14px;
+  font-size: fn.font-size(450);
   font-style: normal;
   font-weight: 500;
   line-height: 150%;
@@ -17,7 +18,7 @@
 .Tooltip__Title {
   @include TooltipText;
 
-  margin-bottom: 8px;
+  margin-bottom: fn.spacing(200);
 }
 
 .Tooltip__Content {

--- a/packages/core/src/components/shared/MultiItemInput/TileShell.tsx
+++ b/packages/core/src/components/shared/MultiItemInput/TileShell.tsx
@@ -3,7 +3,7 @@
 import { defaultAnimateLayoutChanges, useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { Loader } from '@mantine/core';
-import { ColorAqua500, IconDragMenu, IconXCircle } from '@pop-ui/foundation';
+import { ColorAqua500, ColorGray600, IconDragMenu, IconXCircle } from '@pop-ui/foundation';
 import { useState } from 'react';
 
 import styles from './styles.module.scss';
@@ -142,7 +142,7 @@ export function TileShell({
               {...listeners}
               aria-label="드래그로 순서 변경"
             >
-              <IconDragMenu size={20} color="#808080" />
+              <IconDragMenu size={20} color={ColorGray600} />
             </button>
           )}
 

--- a/packages/core/src/components/shared/MultiItemInput/styles.module.scss
+++ b/packages/core/src/components/shared/MultiItemInput/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../variables.scss' as *;
+@use '../functions' as fn;
 
 // ─── TileShell ────────────────────────────────────────────────────────────────
 
@@ -32,7 +33,7 @@
 .Tile {
   position: relative;
   border-radius: 8px;
-  border: 1px solid $color-gray-100;
+  border: fn.border-width(25) solid $color-gray-100;
   overflow: hidden;
   flex-shrink: 0;
   transition: opacity 0.2s ease, border-color 0.2s ease;
@@ -55,17 +56,17 @@
 
 .ActionBar {
   width: 100%;
-  padding-top: 8px;
+  padding-top: fn.spacing(200);
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 4px;
+  gap: fn.spacing(100);
 }
 
 .DragHandle {
   flex-shrink: 0;
-  width: 24px;
-  height: 24px;
+  width: fn.spacing(600);
+  height: fn.spacing(600);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -82,7 +83,7 @@
 
 .LinkButton {
   flex: 1;
-  font-size: 12px;
+  font-size: fn.font-size(400);
   font-weight: 500;
   line-height: 1.2;
   color: $color-aqua-600;
@@ -127,7 +128,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 12px;
+    gap: fn.spacing(300);
   }
 }
 
@@ -137,7 +138,7 @@
 
 .DropzoneOuter .PlaceholderError {
   background-color: $color-red-50;
-  border: 1.5px solid $color-red-500 !important;
+  border: fn.border-width(37) solid $color-red-500 !important;
 }
 
 .PlaceholderText {
@@ -149,7 +150,7 @@
 
   span {
     color: $color-aqua-700;
-    font-size: 16px;
+    font-size: fn.font-size(500);
     font-weight: 500;
     line-height: 1.4;
   }

--- a/packages/core/src/components/shared/_border-width-map.scss
+++ b/packages/core/src/components/shared/_border-width-map.scss
@@ -1,0 +1,12 @@
+
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+$border-width-tokens: (
+  'border-width-25': 1,
+  'border-width-37': 1.5,
+  'border-width-50': 2,
+  'border-width-100': 4,
+  'border-width-200': 8
+);

--- a/packages/core/src/components/shared/_font-size-map.scss
+++ b/packages/core/src/components/shared/_font-size-map.scss
@@ -1,0 +1,35 @@
+
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+$font-size-tokens: (
+  'web-h1-40-bold-font-size': 40,
+  'web-h2-32-bold-font-size': 32,
+  'web-h3-28-bold-font-size': 28,
+  'web-h4-24-bold-font-size': 24,
+  'web-h5-20-bold-font-size': 20,
+  'web-t1-16-sb-font-size': 16,
+  'web-t2-14-sb-font-size': 14,
+  'web-t3-12-sb-font-size': 12,
+  'web-b1-18-sb-font-size': 18,
+  'web-b2-18-m-font-size': 18,
+  'web-b2-16-sb-font-size': 16,
+  'web-b2-16-m-font-size': 16,
+  'web-b3-14-sb-font-size': 14,
+  'web-b3-14-m-font-size': 14,
+  'web-c1-12-sb-font-size': 12,
+  'web-c1-12-m-font-size': 12,
+  'web-c2-11-m-font-size': 11,
+  'font-size-375': 11,
+  'font-size-400': 12,
+  'font-size-450': 14,
+  'font-size-500': 16,
+  'font-size-550': 18,
+  'font-size-600': 20,
+  'font-size-700': 24,
+  'font-size-800': 28,
+  'font-size-900': 32,
+  'font-size-1000': 36,
+  'font-size-1100': 40
+);

--- a/packages/core/src/components/shared/_functions.scss
+++ b/packages/core/src/components/shared/_functions.scss
@@ -1,0 +1,32 @@
+@use 'sass:map';
+@use 'spacing-map' as spacing-map;
+@use 'font-size-map' as font-size-map;
+@use 'border-width-map' as border-width-map;
+
+// unitless 토큰 map을 px 값으로 변환하는 함수들.
+// 키는 style-dictionary가 생성한 풀네임(spacing-400, font-size-500, border-width-37).
+// step만 넘기면(예: spacing(400)) 내부에서 풀네임 키를 조립한다.
+
+@function spacing($step) {
+  $key: 'spacing-#{$step}';
+  @if not map.has-key(spacing-map.$spacing-tokens, $key) {
+    @error 'Unknown spacing token: #{$key}';
+  }
+  @return #{map.get(spacing-map.$spacing-tokens, $key)}px;
+}
+
+@function font-size($step) {
+  $key: 'font-size-#{$step}';
+  @if not map.has-key(font-size-map.$font-size-tokens, $key) {
+    @error 'Unknown font-size token: #{$key}';
+  }
+  @return #{map.get(font-size-map.$font-size-tokens, $key)}px;
+}
+
+@function border-width($step) {
+  $key: 'border-width-#{$step}';
+  @if not map.has-key(border-width-map.$border-width-tokens, $key) {
+    @error 'Unknown border-width token: #{$key}';
+  }
+  @return #{map.get(border-width-map.$border-width-tokens, $key)}px;
+}

--- a/packages/core/src/components/shared/_spacing-map.scss
+++ b/packages/core/src/components/shared/_spacing-map.scss
@@ -1,0 +1,23 @@
+
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+$spacing-tokens: (
+  'spacing-100': 4,
+  'spacing-150': 6,
+  'spacing-200': 8,
+  'spacing-300': 12,
+  'spacing-400': 16,
+  'spacing-500': 20,
+  'spacing-600': 24,
+  'spacing-700': 28,
+  'spacing-800': 32,
+  'spacing-900': 36,
+  'spacing-1000': 40,
+  'spacing-1100': 44,
+  'spacing-1200': 48,
+  'spacing-1300': 52,
+  'spacing-1400': 56,
+  'spacing-1500': 60
+);

--- a/packages/foundation/config.js
+++ b/packages/foundation/config.js
@@ -23,6 +23,24 @@ export default {
           destination: 'variables.scss',
           format: 'scss/variables',
         },
+        {
+          destination: '_spacing-map.scss',
+          format: 'scss/map-flat',
+          filter: { type: 'spacing' },
+          options: { mapName: 'spacing-tokens' },
+        },
+        {
+          destination: '_font-size-map.scss',
+          format: 'scss/map-flat',
+          filter: { type: 'fontSizes' },
+          options: { mapName: 'font-size-tokens' },
+        },
+        {
+          destination: '_border-width-map.scss',
+          format: 'scss/map-flat',
+          filter: { type: 'borderWidth' },
+          options: { mapName: 'border-width-tokens' },
+        },
       ],
     },
     ts: {


### PR DESCRIPTION
## 배경

pop-ui "제대로 된 기반" 작업의 두 번째 하위 프로젝트(prop 타입 단일원천화 #123 다음). CLAUDE.md가 "토큰이 단일 진실원천"이라 선언하는데 실제로는 일부 값이 파이프라인을 우회한다. **값이 토큰과 정확히 일치하는 범위에서만** 이 모순을 메운다.

실측 조사로 범위를 좁힘 — SCSS는 이미 색상 토큰화돼 있었고(raw hex 1개), 진짜 하드코딩은 성격이 다른 3덩어리였다. 이번엔 **① 정확일치 hex + ③ SCSS px**만. 팔레트 hex(디자이너 결정 필요)와 JS px(spacing.ts 생성 선행)는 별도.

## 변경 사항 (6 커밋)

1. **`feat(foundation)`** — style-dictionary가 spacing/font-size/border-width의 SCSS map을 생성(`_*-map.scss`), `_functions.scss`가 unitless 토큰을 px로 변환(`fn.spacing(400)`→16px). 기존 `variables.scss` 불변.
2. **`refactor(core)`** — 정확일치 하드코딩 hex 15개를 foundation 색상 상수로(`#e03131`→`ColorRed700` 등). near-miss는 제외.
3. **`test(core)`** — hex 리팩터로 컴포넌트가 새 색상 상수를 쓰게 되어 ImageInput/LottieInput 테스트 mock에 상수 추가(회귀 수정). 부수적으로 LottieInput mock의 틀린 `ColorAqua500` 값도 교정.
4. **`refactor(core)`** — 18개 컴포넌트 SCSS의 정확일치 px를 `fn.spacing()`/`fn.font-size()`/`fn.border-width()`로. outlier(스케일에 없는 값)는 raw px 유지.
5. **`refactor(core)`** — CalendarDatePicker 데모 SCSS 토큰화 + 클래스명 PascalCase BEM 정합(pre-existing lint 부채 해소, stories 참조 동기화).
6. **`docs`** — CLAUDE.md에 SCSS px 함수 컨벤션 추가.

## 성격 — 시각 회귀 0

**값이 정확히 일치하는 것만 교체**하므로 픽셀 불변. 핵심 안전장치는 **빌드 CSS diff = 0**:
- base(main) vs HEAD의 `core.css`가 **byte-identical**(266,198 bytes 동일) — 최종 검증됨.
- px→토큰은 산술이 아니라 lookup(`font-size(450)`=14px 등), 함수에 `@error` 가드 → 잘못된 스텝은 빌드 실패로 즉시 발견.
- hex는 값 동일 상수로만 교체(near-miss 제외).

## 검증

- `yarn token-build` → `variables.scss` drift 0, map 정상 생성
- `yarn typecheck` (4패키지) ✓
- `yarn build:core` → **base 대비 CSS diff 0** ✓
- 157개 컴포넌트 테스트 통과 ✓

## 범위 밖 (별도 하위 프로젝트)

- 팔레트 hex(`shared/styles.ts`, `Map/markerStyles.ts`) — 토큰 없는 브랜드/near-miss 값, 디자이너 결정 필요.
- JS(`.ts/.tsx`)의 px — import할 spacing JS 상수 없음, `spacing.ts` 생성 선행 필요.
- 스케일에 없는 outlier px — raw 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)