### PR TITLE
test(core): 미테스트 컴포넌트 7개 테스트 추가 + 테스트 typecheck 포함

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "typecheck": "tsc",
+    "typecheck": "tsc && tsc -p tsconfig.test.json",
     "lint": "eslint src --max-warnings 0",
     "lint:fix": "eslint src --fix",
     "preview": "vite preview"

--- a/packages/core/src/components/CalendarDatePicker/CalendarDatePicker.test.tsx
+++ b/packages/core/src/components/CalendarDatePicker/CalendarDatePicker.test.tsx
@@ -10,6 +10,9 @@ interface IMockedDatePickerProps {
   nextIcon?: React.ReactNode;
   renderDay?: (date: Date) => React.ReactNode;
   onChange?: (value: unknown) => void;
+  getDayProps?: (date: string) => {
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  };
   [key: string]: unknown;
 }
 
@@ -194,8 +197,7 @@ describe('CalendarDatePicker', () => {
       />,
     );
 
-    const props = mockMantineDatePicker.mock.calls[0]?.[0];
-    const outsideMonthDate = new Date('2025-10-30T00:00:00.000Z');
+    const props = mockMantineDatePicker.mock.calls[0]?.[0] as IMockedDatePickerProps;
     const insideMonthDate = new Date('2025-11-12T00:00:00.000Z');
 
     act(() => {

--- a/packages/core/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.stories.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { DatePicker } from '.';
 
-import type { IDatePickerProps } from '.';
+import type { IDatePickerProps } from './types';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const stackStyle = {

--- a/packages/core/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,176 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const mockMantineSelect = vi.fn(
+  ({ className, size, error, rightSection }: Record<string, unknown>) => (
+    <div
+      className={String(className ?? '')}
+      data-error={String(error ?? '')}
+      data-size={String(size ?? '')}
+      data-testid="mantine-select"
+    >
+      {rightSection as React.ReactNode}
+    </div>
+  ),
+);
+
+vi.mock('@mantine/core', () => {
+  const Input = (props: Record<string, unknown>) => (
+    <div data-testid="mantine-input">{props.children as React.ReactNode}</div>
+  );
+
+  Object.assign(Input, {
+    Label: (props: Record<string, unknown>) => (
+      <label data-testid="input-label">{props.children as React.ReactNode}</label>
+    ),
+    Description: (props: Record<string, unknown>) => (
+      <div data-testid="input-description">{props.children as React.ReactNode}</div>
+    ),
+    Error: (props: Record<string, unknown>) => (
+      <div data-testid="input-error">{props.children as React.ReactNode}</div>
+    ),
+  });
+
+  return {
+    Select: (props: Record<string, unknown>) => mockMantineSelect(props),
+    Input,
+    Tooltip: (props: Record<string, unknown>) => (
+      <div data-testid="mantine-tooltip">{props.children as React.ReactNode}</div>
+    ),
+  };
+});
+
+vi.mock('@pop-ui/foundation', () => ({
+  ColorBlack: '#000000',
+  ColorGray100: '#f5f5f5',
+  IconInfoCircle: ({ size }: { size?: number }) => (
+    <span data-size={String(size ?? '')} data-testid="icon-info" />
+  ),
+  IconChevronUp: ({ size }: { size?: number }) => (
+    <span data-size={String(size ?? '')} data-testid="chevron-up" />
+  ),
+  IconChevronDown: ({ size }: { size?: number }) => (
+    <span data-size={String(size ?? '')} data-testid="chevron-down" />
+  ),
+}));
+
+import { Dropdown } from '.';
+import styles from './styles.module.scss';
+
+import type { Root } from 'react-dom/client';
+
+interface IRenderedApp {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderApp = (ui: React.ReactNode): IRenderedApp => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return { container, root };
+};
+
+const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
+  act(() => {
+    root.unmount();
+  });
+
+  container.remove();
+};
+
+describe('Dropdown', () => {
+  afterEach(() => {
+    mockMantineSelect.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('forwards errorMsg to Select as the error prop and renders Input.Error', () => {
+    const view = renderApp(<Dropdown data={['A', 'B']} errorMsg="필수 항목입니다" />);
+
+    const props = mockMantineSelect.mock.calls[0]?.[0];
+
+    expect(props.error).toBe('필수 항목입니다');
+
+    const error = view.container.querySelector('[data-testid="input-error"]');
+
+    expect(error?.textContent).toBe('필수 항목입니다');
+
+    cleanupRenderedApp(view);
+  });
+
+  it('toggles the chevron icon based on open/close callbacks from Select', () => {
+    const view = renderApp(<Dropdown data={['A', 'B']} />);
+
+    expect(view.container.querySelector('[data-testid="chevron-down"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="chevron-up"]')).toBeNull();
+
+    const openProps = mockMantineSelect.mock.calls[0]?.[0];
+
+    act(() => {
+      (openProps.onDropdownOpen as () => void)();
+    });
+
+    expect(view.container.querySelector('[data-testid="chevron-up"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="chevron-down"]')).toBeNull();
+
+    const closeProps = mockMantineSelect.mock.calls[mockMantineSelect.mock.calls.length - 1]?.[0];
+
+    act(() => {
+      (closeProps.onDropdownClose as () => void)();
+    });
+
+    expect(view.container.querySelector('[data-testid="chevron-down"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="chevron-up"]')).toBeNull();
+
+    cleanupRenderedApp(view);
+  });
+
+  it('maps each size to the matching Select class name and chevron size', () => {
+    const cases: Array<{
+      size: 'sm' | 'md' | 'lg';
+      className: string;
+      chevronSize: string;
+    }> = [
+      { size: 'sm', className: styles['Dropdown--Small'], chevronSize: '14' },
+      { size: 'md', className: styles['Dropdown--Medium'], chevronSize: '18' },
+      { size: 'lg', className: styles['Dropdown--Large'], chevronSize: '24' },
+    ];
+
+    cases.forEach(({ size, className, chevronSize }) => {
+      const view = renderApp(<Dropdown data={['A', 'B']} size={size} />);
+
+      const props = mockMantineSelect.mock.calls[0]?.[0];
+
+      expect(props.className).toBe(className);
+      expect(props.size).toBe(size);
+
+      const chevron = view.container.querySelector('[data-testid="chevron-down"]');
+
+      expect(chevron?.getAttribute('data-size')).toBe(chevronSize);
+
+      cleanupRenderedApp(view);
+      mockMantineSelect.mockClear();
+    });
+  });
+
+  it('applies the top-label wrapper class by default', () => {
+    const view = renderApp(<Dropdown data={['A', 'B']} label="라벨" />);
+
+    const wrapper = view.container.firstElementChild;
+
+    expect(wrapper?.className).toBe(styles['Dropdown--TopLabel']);
+
+    cleanupRenderedApp(view);
+  });
+});

--- a/packages/core/src/components/Map/markerStyles.test.ts
+++ b/packages/core/src/components/Map/markerStyles.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { getMarkerHTML } from './markerStyles';
+
+import type { ICoord, TMarkerData } from './types';
+
+const position: ICoord = { latitude: 37.5, longitude: 127.0 };
+const base = { id: 'm1', position };
+
+describe('getMarkerHTML', () => {
+  describe('pin', () => {
+    it('renders <img> when icon is present, always with the name', () => {
+      const html = getMarkerHTML({ ...base, type: 'pin', name: '홍길동', icon: 'https://x/i.png' });
+
+      expect(html).toContain('<img src="https://x/i.png"');
+      expect(html).toContain('alt="홍길동"');
+      expect(html).toContain('홍길동');
+      expect(html).not.toContain('<svg');
+    });
+
+    it('renders inline <svg> when icon is absent, still with the name', () => {
+      const html = getMarkerHTML({ ...base, type: 'pin', name: '홍길동' });
+
+      expect(html).toContain('<svg');
+      expect(html).toContain('홍길동');
+      expect(html).not.toContain('<img');
+    });
+  });
+
+  describe('popdeal', () => {
+    it('renders all conditional fields and comma-formats prices', () => {
+      const html = getMarkerHTML({
+        ...base,
+        type: 'popdeal',
+        title: '치킨',
+        price: 10000,
+        originalPrice: 20000,
+        discountRate: 50,
+        category: '음식',
+        active: true,
+      });
+
+      expect(html).toContain('active="true"');
+      expect(html).toContain('음식');
+      expect(html).toContain('20,000원');
+      expect(html).toContain('50%');
+      expect(html).toContain('10,000원');
+    });
+
+    it('omits conditional fields when falsy and marks active="false"', () => {
+      const html = getMarkerHTML({ ...base, type: 'popdeal', title: '치킨', price: 5000 });
+
+      expect(html).toContain('active="false"');
+      expect(html).toContain('5,000원');
+      expect(html).not.toContain('popdeal-marker-category');
+      expect(html).not.toContain('popdeal-marker-original_price');
+      expect(html).not.toContain('popdeal-marker-discount_rate');
+    });
+  });
+
+  describe('pi', () => {
+    it('renders the icon when present', () => {
+      const html = getMarkerHTML({ ...base, type: 'pi', title: '카페', icon: 'https://x/c.png' });
+
+      expect(html).toContain('pi-marker-icon');
+      expect(html).toContain('https://x/c.png');
+      expect(html).toContain('카페');
+    });
+
+    it('omits the icon when absent', () => {
+      const html = getMarkerHTML({ ...base, type: 'pi', title: '카페' });
+
+      expect(html).not.toContain('pi-marker-icon');
+      expect(html).toContain('카페');
+    });
+  });
+
+  describe('pi-expanded', () => {
+    it('renders the address when present', () => {
+      const html = getMarkerHTML({
+        ...base,
+        type: 'pi-expanded',
+        title: '카페',
+        address: '서울시 강남구',
+      });
+
+      expect(html).toContain('pi-expanded-marker-address');
+      expect(html).toContain('서울시 강남구');
+    });
+
+    it('omits the address when absent', () => {
+      const html = getMarkerHTML({ ...base, type: 'pi-expanded', title: '카페' });
+
+      expect(html).not.toContain('pi-expanded-marker-address');
+      expect(html).toContain('카페');
+    });
+  });
+
+  describe('cluster', () => {
+    it('renders the count', () => {
+      const html = getMarkerHTML({ ...base, type: 'cluster', count: 42 });
+
+      expect(html).toContain('42');
+      expect(html).toContain('cluster-marker');
+    });
+  });
+
+  describe('unknown type', () => {
+    it('returns an empty string', () => {
+      const html = getMarkerHTML({ ...base, type: 'nope' } as unknown as TMarkerData);
+
+      expect(html).toBe('');
+    });
+  });
+});

--- a/packages/core/src/components/Map/useLocation.test.tsx
+++ b/packages/core/src/components/Map/useLocation.test.tsx
@@ -1,0 +1,151 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../Toast', () => ({ toast: vi.fn() }));
+
+import { useLocation } from './useLocation';
+import { toast } from '../Toast';
+
+import type { ILocation } from './types';
+import type { Root } from 'react-dom/client';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Harness(props: Parameters<typeof useLocation>[0]) {
+  const { position, isLoading, isError } = useLocation(props);
+  return (
+    <div
+      data-testid="out"
+      data-position={position === null ? 'null' : JSON.stringify(position)}
+      data-loading={String(isLoading)}
+      data-error={String(isError)}
+    />
+  );
+}
+
+interface IState {
+  position: ILocation | null;
+  isLoading: boolean;
+  isError: boolean;
+}
+
+function readState(container: HTMLElement): IState {
+  const el = container.querySelector('[data-testid="out"]') as HTMLElement;
+  const pos = el.dataset.position;
+  return {
+    position: pos === 'null' ? null : (JSON.parse(pos ?? 'null') as ILocation),
+    isLoading: el.dataset.loading === 'true',
+    isError: el.dataset.error === 'true',
+  };
+}
+
+const getCurrentPosition = vi.fn();
+
+function render(props: Parameters<typeof useLocation>[0]) {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Harness {...props} />);
+  });
+  return { container, root };
+}
+
+function rerender(root: Root, props: Parameters<typeof useLocation>[0]) {
+  act(() => {
+    root.render(<Harness {...props} />);
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  getCurrentPosition.mockClear();
+  vi.mocked(toast).mockClear();
+});
+
+function stubGeolocation() {
+  vi.stubGlobal('navigator', { geolocation: { getCurrentPosition } });
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 0;
+  });
+}
+
+describe('useLocation', () => {
+  it('isActive=false 이면 getCurrentPosition을 호출하지 않는다', () => {
+    stubGeolocation();
+    const { container } = render({ isActive: false });
+
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(readState(container).position).toBeNull();
+    expect(readState(container).isError).toBe(false);
+  });
+
+  it('isActive=true success: coords로 position을 채운다', () => {
+    stubGeolocation();
+    const { container, root } = render({ isActive: true });
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    const successCb = getCurrentPosition.mock.calls[0][0] as PositionCallback;
+    act(() => {
+      successCb({
+        coords: { latitude: 37.5, longitude: 127.0 },
+      } as GeolocationPosition);
+    });
+
+    expect(readState(container).position).toEqual({
+      latitude: 37.5,
+      longitude: 127.0,
+    });
+    expect(readState(container).isError).toBe(false);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it('isActive=true error: position null, isError true, toast 호출', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    stubGeolocation();
+    const { container, root } = render({ isActive: true });
+
+    const errorCb = getCurrentPosition.mock.calls[0][1] as PositionErrorCallback;
+    act(() => {
+      errorCb({
+        code: 1,
+        message: 'denied',
+      } as GeolocationPositionError);
+    });
+
+    expect(readState(container).position).toBeNull();
+    expect(readState(container).isError).toBe(true);
+    expect(toast).toHaveBeenCalledTimes(1);
+
+    const arg = vi.mocked(toast).mock.calls[0][0] as { message: string };
+    expect(arg.message).toContain('위치 정보를 불러오는 데 실패했어요.');
+
+    act(() => {
+      root.unmount();
+    });
+    errorSpy.mockRestore();
+  });
+
+  it('single-flight: 콜백 해소 전 리렌더는 getCurrentPosition을 재호출하지 않는다', () => {
+    stubGeolocation();
+    const { root } = render({ isActive: true });
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    // 콜백을 아직 발화하지 않은 상태 → isLoadingRef가 여전히 true
+    rerender(root, { isActive: true });
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/packages/core/src/components/Map/useLocation.test.tsx
+++ b/packages/core/src/components/Map/useLocation.test.tsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 

--- a/packages/core/src/components/Map/useMap.test.tsx
+++ b/packages/core/src/components/Map/useMap.test.tsx
@@ -1,0 +1,161 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => {
+  const addListener = vi.fn();
+  const markerEl = document.createElement('div');
+  markerEl.innerHTML = '<div class="popdeal-marker" active="false"></div>';
+  const markerInstance = { getElement: () => markerEl, setMap: vi.fn() };
+  const MarkerCtor = vi.fn(function (_opts: { icon: { content: string } }) {
+    return markerInstance;
+  });
+  const LatLngCtor = vi.fn(function (this: { lat: number; lng: number }, lat: number, lng: number) {
+    this.lat = lat;
+    this.lng = lng;
+  });
+  const naverStub = {
+    maps: {
+      Marker: MarkerCtor,
+      LatLng: LatLngCtor,
+      Event: { addListener },
+      // used by the clustering effect once markers exist
+      Size: vi.fn(),
+      Point: vi.fn(),
+    },
+  };
+  return { addListener, markerEl, markerInstance, MarkerCtor, LatLngCtor, naverStub };
+});
+
+vi.mock('./NaverMapContext', () => ({
+  useNaverMap: () => ({ naver: h.naverStub }),
+}));
+vi.mock('./markerClustering', () => ({
+  makeMarkerClustering: () =>
+    vi.fn(function () {
+      return { setMap: vi.fn() };
+    }),
+}));
+
+import { getMarkerHTML } from './markerStyles';
+import { useMap } from './useMap';
+
+import type { IPopdealMarkerData } from './types';
+import type { Root } from 'react-dom/client';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type TApi = ReturnType<typeof useMap>;
+
+function Harness({ map, onReady }: { map: naver.maps.Map | null; onReady: (api: TApi) => void }) {
+  const api = useMap(map);
+  React.useEffect(() => {
+    onReady(api);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return <div data-testid="out" />;
+}
+
+const popdeal = (id: string): IPopdealMarkerData => ({
+  id,
+  type: 'popdeal',
+  position: { latitude: 37.5, longitude: 127.0 },
+  title: 'Deal',
+  price: 10000,
+});
+
+describe('useMap', () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    // reset the shared marker element for isolation
+    h.markerEl.innerHTML = '<div class="popdeal-marker" active="false"></div>';
+  });
+
+  function mount(map: naver.maps.Map | null): TApi {
+    let api!: TApi;
+    act(() => {
+      root.render(<Harness map={map} onReady={(a) => (api = a)} />);
+    });
+    return api;
+  }
+
+  it('addMarker with valid map+naver returns the marker and builds icon.content via getMarkerHTML', () => {
+    const api = mount({} as naver.maps.Map);
+    const data = popdeal('p1');
+
+    let result: naver.maps.Marker | null = null;
+    act(() => {
+      result = api.addMarker(data);
+    });
+
+    expect(result).toBe(h.markerInstance);
+    expect(h.MarkerCtor).toHaveBeenCalledTimes(1);
+    const ctorArg = h.MarkerCtor.mock.calls[0]?.[0];
+    expect(ctorArg.icon.content).toBe(getMarkerHTML(data));
+
+    // registration observable via updateMarker working on the id
+    act(() => {
+      api.updateMarker('p1', { active: true });
+    });
+    const div = h.markerEl.querySelector('.popdeal-marker');
+    expect(div?.getAttribute('active')).toBe('true');
+  });
+
+  it('addMarker with map=null returns null and does not construct a Marker', () => {
+    const api = mount(null);
+    let result: naver.maps.Marker | null = h.markerInstance as unknown as naver.maps.Marker;
+    act(() => {
+      result = api.addMarker(popdeal('p2'));
+    });
+    expect(result).toBeNull();
+    expect(h.MarkerCtor).not.toHaveBeenCalled();
+  });
+
+  it('addMarker registers onClick via naver.maps.Event.addListener for click', () => {
+    const api = mount({} as naver.maps.Map);
+    act(() => {
+      api.addMarker({ ...popdeal('p3'), onClick: vi.fn() });
+    });
+    expect(h.addListener).toHaveBeenCalledWith(h.markerInstance, 'click', expect.any(Function));
+  });
+
+  it('updateMarker toggles the active attribute on the .popdeal-marker div', () => {
+    const api = mount({} as naver.maps.Map);
+    act(() => {
+      api.addMarker(popdeal('p4'));
+    });
+    const div = h.markerEl.querySelector('.popdeal-marker');
+
+    act(() => {
+      api.updateMarker('p4', { active: true });
+    });
+    expect(div?.getAttribute('active')).toBe('true');
+
+    act(() => {
+      api.updateMarker('p4', { active: false });
+    });
+    expect(div?.getAttribute('active')).toBe('false');
+  });
+
+  it('updateMarker on an unknown id is a no-op and does not throw', () => {
+    const api = mount({} as naver.maps.Map);
+    expect(() => {
+      act(() => {
+        api.updateMarker('does-not-exist', { active: true });
+      });
+    }).not.toThrow();
+  });
+});

--- a/packages/core/src/components/MapInfo/MapInfo.test.tsx
+++ b/packages/core/src/components/MapInfo/MapInfo.test.tsx
@@ -81,6 +81,7 @@ describe('MapInfo', () => {
     mockMapOptions.length = 0;
     mockNaverClientId = undefined;
     document.body.innerHTML = '';
+    vi.unstubAllGlobals();
   });
 
   it('renders the NoClientId guidance and no map when naverClientId is missing', () => {
@@ -141,7 +142,6 @@ describe('MapInfo', () => {
     expect(mockToast).toHaveBeenCalledWith('주소 복사 완료');
 
     cleanupRenderedApp(view);
-    vi.unstubAllGlobals();
   });
 
   it('uses a custom addressCopied toast message when provided', () => {
@@ -162,7 +162,6 @@ describe('MapInfo', () => {
     expect(mockToast).toHaveBeenCalledWith('복사됨!');
 
     cleanupRenderedApp(view);
-    vi.unstubAllGlobals();
   });
 
   it('subtracts the address bar height to compute the map preview height', () => {

--- a/packages/core/src/components/MapInfo/MapInfo.test.tsx
+++ b/packages/core/src/components/MapInfo/MapInfo.test.tsx
@@ -1,0 +1,175 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+let mockNaverClientId: string | undefined;
+const mockMapOptions: Record<string, unknown>[] = [];
+
+vi.mock('../Map', () => ({
+  Map: ({ options }: { options?: Record<string, unknown> }) => {
+    if (options) mockMapOptions.push(options);
+    return <div data-testid="map" />;
+  },
+  NaverMapProvider: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../Button', () => ({
+  Button: ({ children }: { children?: React.ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock('../../theme', () => ({
+  usePopUIConfig: () => ({ naverClientId: mockNaverClientId }),
+}));
+
+const mockToast = vi.fn();
+vi.mock('../Toast', () => ({
+  toast: (message: string) => mockToast(message),
+}));
+
+vi.mock('@pop-ui/foundation', () => ({
+  IconMap: () => <span />,
+  IconMapMarker: () => <span />,
+  ColorAqua500: '#0fd3d8',
+  ColorGray800: '#333',
+}));
+
+import { MapInfo } from '.';
+import styles from './styles.module.scss';
+
+import type { IMapInfoProps } from './types';
+import type { Root } from 'react-dom/client';
+
+interface IRenderedApp {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderApp = (ui: React.ReactNode): IRenderedApp => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return { container, root };
+};
+
+const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
+  act(() => {
+    root.unmount();
+  });
+
+  container.remove();
+};
+
+const location: IMapInfoProps['location'] = {
+  title: '스타벅스',
+  address: '서울시 강남구 테헤란로 123',
+  latitude: 37.5,
+  longitude: 127.0,
+};
+
+describe('MapInfo', () => {
+  afterEach(() => {
+    mockToast.mockClear();
+    mockMapOptions.length = 0;
+    mockNaverClientId = undefined;
+    document.body.innerHTML = '';
+  });
+
+  it('renders the NoClientId guidance and no map when naverClientId is missing', () => {
+    const view = renderApp(<MapInfo location={location} />);
+
+    const noClientId = view.container.querySelector(`.${styles.MapInfo__NoClientId}`);
+    expect(noClientId).not.toBeNull();
+    expect(noClientId?.textContent).toContain('naverClientId');
+    expect(view.container.querySelector('[data-testid="map"]')).toBeNull();
+
+    cleanupRenderedApp(view);
+  });
+
+  it('builds the default direction href from the location title', () => {
+    const view = renderApp(<MapInfo location={location} naverClientId="test-id" />);
+
+    const link = view.container.querySelector(`.${styles.MapInfo__DirectionLink}`);
+    expect(link?.getAttribute('href')).toBe(
+      `https://map.naver.com/p/search/${encodeURIComponent('스타벅스')}`,
+    );
+
+    cleanupRenderedApp(view);
+  });
+
+  it('uses an explicit direction url when provided', () => {
+    const view = renderApp(
+      <MapInfo location={location} naverClientId="test-id" direction={{ url: 'https://custom' }} />,
+    );
+
+    const link = view.container.querySelector(`.${styles.MapInfo__DirectionLink}`);
+    expect(link?.getAttribute('href')).toBe('https://custom');
+
+    cleanupRenderedApp(view);
+  });
+
+  it('renders the default direction label', () => {
+    const view = renderApp(<MapInfo location={location} naverClientId="test-id" />);
+
+    const link = view.container.querySelector(`.${styles.MapInfo__DirectionLink}`);
+    expect(link?.textContent).toContain('길찾기');
+
+    cleanupRenderedApp(view);
+  });
+
+  it('copies the address and shows the default toast when the address is clicked', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const view = renderApp(<MapInfo location={location} naverClientId="test-id" />);
+
+    const address = view.container.querySelector(`.${styles.MapInfo__Address}`) as HTMLElement;
+
+    act(() => {
+      address.click();
+    });
+
+    expect(writeText).toHaveBeenCalledWith(location.address);
+    expect(mockToast).toHaveBeenCalledWith('주소 복사 완료');
+
+    cleanupRenderedApp(view);
+    vi.unstubAllGlobals();
+  });
+
+  it('uses a custom addressCopied toast message when provided', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const view = renderApp(
+      <MapInfo location={location} naverClientId="test-id" toast={{ addressCopied: '복사됨!' }} />,
+    );
+
+    const address = view.container.querySelector(`.${styles.MapInfo__Address}`) as HTMLElement;
+
+    act(() => {
+      address.click();
+    });
+
+    expect(writeText).toHaveBeenCalledWith(location.address);
+    expect(mockToast).toHaveBeenCalledWith('복사됨!');
+
+    cleanupRenderedApp(view);
+    vi.unstubAllGlobals();
+  });
+
+  it('subtracts the address bar height to compute the map preview height', () => {
+    const view = renderApp(<MapInfo location={location} naverClientId="test-id" height={300} />);
+
+    expect(mockMapOptions[0]?.height).toBe('240px');
+
+    cleanupRenderedApp(view);
+  });
+});

--- a/packages/core/src/components/Pagination/Pagination.test.tsx
+++ b/packages/core/src/components/Pagination/Pagination.test.tsx
@@ -1,0 +1,166 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+vi.mock('@pop-ui/foundation', () => ({
+  IconChevronLeft: () => <span data-testid="chevron-left" />,
+  IconChevronRight: () => <span data-testid="chevron-right" />,
+}));
+
+import { Pagination } from '.';
+import style from './style.module.scss';
+
+import type { Root } from 'react-dom/client';
+
+interface IRenderedApp {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderApp = (ui: React.ReactNode): IRenderedApp => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return { container, root };
+};
+
+const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
+  act(() => {
+    root.unmount();
+  });
+
+  container.remove();
+};
+
+const getButtons = (container: HTMLElement): HTMLButtonElement[] =>
+  Array.from(container.querySelectorAll('button'));
+
+const getPageButton = (container: HTMLElement, label: string): HTMLButtonElement | undefined =>
+  getButtons(container).find((button) => button.textContent === label);
+
+const getArrows = (container: HTMLElement): HTMLButtonElement[] =>
+  getButtons(container).filter((button) => button.classList.contains(style['Pagination__Arrow']));
+
+describe('Pagination', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('renders first-window page labels 1..5 with no prev arrow and a next arrow', () => {
+    const view = renderApp(
+      <Pagination currentPageIdx={0} totalLength={1000} rowsPerPage={50} paginationSize={5} />,
+    );
+
+    const labels = getButtons(view.container)
+      .filter((button) => !button.classList.contains(style['Pagination__Arrow']))
+      .map((button) => button.textContent);
+
+    expect(labels).toEqual(['1', '2', '3', '4', '5']);
+    expect(view.container.querySelector('[data-testid="chevron-left"]')).toBeNull();
+    expect(view.container.querySelector('[data-testid="chevron-right"]')).not.toBeNull();
+
+    cleanupRenderedApp(view);
+  });
+
+  it('fires onPageChange(label - 1) when a page button is clicked', () => {
+    const onPageChange = vi.fn();
+    const view = renderApp(
+      <Pagination
+        currentPageIdx={0}
+        totalLength={1000}
+        rowsPerPage={50}
+        paginationSize={5}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    const pageThree = getPageButton(view.container, '3');
+
+    act(() => {
+      pageThree?.click();
+    });
+
+    expect(onPageChange).toHaveBeenCalledTimes(1);
+    expect(onPageChange).toHaveBeenCalledWith(2);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('applies the active class to the current page', () => {
+    const view = renderApp(
+      <Pagination currentPageIdx={2} totalLength={1000} rowsPerPage={50} paginationSize={5} />,
+    );
+
+    const pageThree = getPageButton(view.container, '3');
+    const pageTwo = getPageButton(view.container, '2');
+
+    expect(pageThree?.className).toBe(style['Pagination__PageIndex--Active']);
+    expect(pageTwo?.className).toBe(style['Pagination__PageIndex']);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('skips page buttons past the total page count (overflow guard)', () => {
+    const view = renderApp(
+      <Pagination currentPageIdx={0} totalLength={120} rowsPerPage={50} paginationSize={5} />,
+    );
+
+    const labels = getButtons(view.container)
+      .filter((button) => !button.classList.contains(style['Pagination__Arrow']))
+      .map((button) => button.textContent);
+
+    // ceil(120 / 50) = 3 pages
+    expect(labels).toEqual(['1', '2', '3']);
+    expect(getPageButton(view.container, '4')).toBeUndefined();
+    expect(getPageButton(view.container, '5')).toBeUndefined();
+
+    cleanupRenderedApp(view);
+  });
+
+  it('shows the prev arrow on the second window and fires onPageChange(4) on prev click', () => {
+    const onPageChange = vi.fn();
+    const view = renderApp(
+      <Pagination
+        currentPageIdx={5}
+        totalLength={1000}
+        rowsPerPage={50}
+        paginationSize={5}
+        onPageChange={onPageChange}
+      />,
+    );
+
+    // second window labels: floor(5/5)*5 + index + 1 => 6..10
+    const labels = getButtons(view.container)
+      .filter((button) => !button.classList.contains(style['Pagination__Arrow']))
+      .map((button) => button.textContent);
+
+    expect(labels).toEqual(['6', '7', '8', '9', '10']);
+
+    // both arrows present: prev (5 >= 5), next (10 < 20)
+    expect(view.container.querySelector('[data-testid="chevron-left"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="chevron-right"]')).not.toBeNull();
+
+    const prevArrow = getArrows(view.container).find(
+      (button) => button.querySelector('[data-testid="chevron-left"]') !== null,
+    );
+
+    act(() => {
+      prevArrow?.click();
+    });
+
+    // 5 - ((5 % 5) + 1) = 4
+    expect(onPageChange).toHaveBeenCalledTimes(1);
+    expect(onPageChange).toHaveBeenCalledWith(4);
+
+    cleanupRenderedApp(view);
+  });
+});

--- a/packages/core/src/components/SearchBar/SearchBar.test.tsx
+++ b/packages/core/src/components/SearchBar/SearchBar.test.tsx
@@ -1,0 +1,185 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const mockAutocomplete = vi.fn(
+  ({ className, size, error, rightSection, onChange }: Record<string, unknown>) => (
+    <div
+      className={String(className)}
+      data-error={String(error ?? '')}
+      data-size={String(size ?? '')}
+      data-testid="mantine-autocomplete"
+    >
+      <input
+        data-testid="autocomplete-input"
+        onChange={(e) => (onChange as ((value: string) => void) | undefined)?.(e.target.value)}
+      />
+      <div data-testid="right-section">{rightSection as React.ReactNode}</div>
+    </div>
+  ),
+);
+
+vi.mock('@mantine/core', () => {
+  const Input = Object.assign(
+    (props: Record<string, unknown>) => <div>{props.children as React.ReactNode}</div>,
+    {
+      Label: (props: Record<string, unknown>) => <label>{props.children as React.ReactNode}</label>,
+      Description: (props: Record<string, unknown>) => (
+        <div>{props.children as React.ReactNode}</div>
+      ),
+      Error: (props: Record<string, unknown>) => <div>{props.children as React.ReactNode}</div>,
+    },
+  );
+
+  return {
+    Autocomplete: (props: Record<string, unknown>) => mockAutocomplete(props),
+    Input,
+    Tooltip: (props: Record<string, unknown>) => <div>{props.children as React.ReactNode}</div>,
+  };
+});
+
+vi.mock('@pop-ui/foundation', () => ({
+  IconInfoCircle: () => <span data-testid="icon-info" />,
+  IconX: () => <span data-testid="icon-x" />,
+  IconSearch: () => <span data-testid="icon-search" />,
+}));
+
+import { SearchBar } from '.';
+import styles from './styles.module.scss';
+
+import type { Root } from 'react-dom/client';
+
+interface IRenderedApp {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderApp = (ui: React.ReactNode): IRenderedApp => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return { container, root };
+};
+
+const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
+  act(() => {
+    root.unmount();
+  });
+
+  container.remove();
+};
+
+const latestProps = () =>
+  mockAutocomplete.mock.calls[mockAutocomplete.mock.calls.length - 1]?.[0] as Record<
+    string,
+    unknown
+  >;
+
+describe('SearchBar', () => {
+  afterEach(() => {
+    mockAutocomplete.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('transforms the Autocomplete payload into a string for the user onChange', () => {
+    const onChange = vi.fn();
+    const view = renderApp(<SearchBar onChange={onChange} />);
+
+    const onChangeHandler = latestProps().onChange as (value: string) => void;
+
+    act(() => {
+      onChangeHandler('hello');
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('hello');
+    expect(typeof onChange.mock.calls[0]?.[0]).toBe('string');
+
+    cleanupRenderedApp(view);
+  });
+
+  it('renders the clear button only when onClear is provided and text has been typed', () => {
+    const onChange = vi.fn();
+    const onClear = vi.fn();
+    const view = renderApp(<SearchBar onChange={onChange} onClear={onClear} />);
+
+    // textCount starts at 0 -> no clear button
+    expect(latestProps().rightSection).toBeUndefined();
+
+    // type -> drives textCount > 0
+    const onChangeHandler = latestProps().onChange as (value: string) => void;
+    act(() => {
+      onChangeHandler('abc');
+    });
+
+    const clearButton = view.container.querySelector(`.${styles['SearchBar__ClearButton']}`);
+    expect(clearButton).not.toBeNull();
+
+    act(() => {
+      (clearButton as HTMLElement).click();
+    });
+    expect(onClear).toHaveBeenCalledTimes(1);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('omits the clear button when onClear is absent even after typing', () => {
+    const onChange = vi.fn();
+    const view = renderApp(<SearchBar onChange={onChange} />);
+
+    const onChangeHandler = latestProps().onChange as (value: string) => void;
+    act(() => {
+      onChangeHandler('abc');
+    });
+
+    expect(latestProps().rightSection).toBeUndefined();
+    expect(view.container.querySelector(`.${styles['SearchBar__ClearButton']}`)).toBeNull();
+
+    cleanupRenderedApp(view);
+  });
+
+  it('maps size to the matching Autocomplete className', () => {
+    const small = renderApp(<SearchBar size="sm" />);
+    expect(latestProps().className).toBe(styles['SearchBar--Small']);
+    cleanupRenderedApp(small);
+    mockAutocomplete.mockClear();
+
+    const medium = renderApp(<SearchBar size="md" />);
+    expect(latestProps().className).toBe(styles['SearchBar--Medium']);
+    cleanupRenderedApp(medium);
+    mockAutocomplete.mockClear();
+
+    const large = renderApp(<SearchBar size="lg" />);
+    expect(latestProps().className).toBe(styles['SearchBar--Large']);
+    cleanupRenderedApp(large);
+  });
+
+  it('defaults to the medium className when size is omitted', () => {
+    const view = renderApp(<SearchBar />);
+    expect(latestProps().className).toBe(styles['SearchBar--Medium']);
+    cleanupRenderedApp(view);
+  });
+
+  it('forwards errorMsg to the Autocomplete error prop', () => {
+    const view = renderApp(<SearchBar errorMsg="required field" />);
+    expect(latestProps().error).toBe('required field');
+    cleanupRenderedApp(view);
+  });
+
+  it('applies the top-label wrapper class by default', () => {
+    const view = renderApp(<SearchBar />);
+    const wrapper = view.container.querySelector(`.${styles['SearchBar--TopLabel']}`);
+    expect(wrapper).not.toBeNull();
+    expect(view.container.querySelector(`.${styles['SearchBar--LeftLabel']}`)).toBeNull();
+    cleanupRenderedApp(view);
+  });
+});

--- a/packages/core/src/components/Toggle/Toggle.test.tsx
+++ b/packages/core/src/components/Toggle/Toggle.test.tsx
@@ -1,0 +1,134 @@
+import React, { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+const mockSwitch = vi.fn(
+  ({
+    className,
+    size,
+    labelPosition,
+    disabled,
+    onChange,
+    styles: stylesProp,
+  }: Record<string, unknown>) => (
+    <div className={String(className)} data-labelposition={String(labelPosition ?? '')}>
+      <input
+        disabled={Boolean(disabled)}
+        onChange={onChange as React.ChangeEventHandler<HTMLInputElement> | undefined}
+        type="checkbox"
+      />
+      <span data-size={String(size ?? '')} data-styles={typeof stylesProp} />
+    </div>
+  ),
+);
+
+vi.mock('@mantine/core', () => ({
+  Switch: (props: Record<string, unknown>) => mockSwitch(props),
+}));
+
+vi.mock('@pop-ui/foundation', () => ({ ColorAqua500: '#0fd3d8' }));
+
+import { Toggle } from '.';
+import styles from './styles.module.scss';
+
+import type { Root } from 'react-dom/client';
+
+interface IRenderedApp {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderApp = (ui: React.ReactNode): IRenderedApp => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(ui);
+  });
+
+  return { container, root };
+};
+
+const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
+  act(() => {
+    root.unmount();
+  });
+
+  container.remove();
+};
+
+type TStylesFn = () => { track: { width: number; backgroundColor?: string; borderColor?: string } };
+
+const getStyles = (call: number): TStylesFn => mockSwitch.mock.calls[call]?.[0].styles;
+
+describe('Toggle', () => {
+  afterEach(() => {
+    mockSwitch.mockClear();
+    document.body.innerHTML = '';
+  });
+
+  it('uses the medium class, right label position, and 50px track width by default', () => {
+    const view = renderApp(<Toggle />);
+
+    const props = mockSwitch.mock.calls[0]?.[0];
+
+    expect(props.className).toBe(styles['Toggle--Medium']);
+    expect(props.labelPosition).toBe('right');
+    expect(getStyles(0)().track.width).toBe(50);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('maps sm and lg sizes to matching class names and track widths', () => {
+    const view = renderApp(
+      <>
+        <Toggle size="sm" />
+        <Toggle size="lg" />
+      </>,
+    );
+
+    const smallProps = mockSwitch.mock.calls[0]?.[0];
+    const largeProps = mockSwitch.mock.calls[1]?.[0];
+
+    expect(smallProps.className).toBe(styles['Toggle--Small']);
+    expect(getStyles(0)().track.width).toBe(38);
+    expect(largeProps.className).toBe(styles['Toggle--Large']);
+    expect(getStyles(1)().track.width).toBe(67);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('forwards the change event to the user-provided onChange', () => {
+    const onChange = vi.fn();
+    const view = renderApp(<Toggle onChange={onChange} />);
+
+    const input = view.container.querySelector('input');
+
+    act(() => {
+      input?.click();
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(
+      (onChange.mock.calls[0]?.[0] as React.ChangeEvent<HTMLInputElement>).target.checked,
+    ).toBe(true);
+
+    cleanupRenderedApp(view);
+  });
+
+  it('seeds isChecked from the checked prop and reflects it in the track color', () => {
+    const view = renderApp(<Toggle checked />);
+
+    const track = getStyles(0)().track;
+
+    expect(track.backgroundColor).toBe('#0fd3d8 !important');
+    expect(track.borderColor).toBe('#0fd3d8 !important');
+
+    cleanupRenderedApp(view);
+  });
+});

--- a/packages/core/src/components/Toggle/Toggle.test.tsx
+++ b/packages/core/src/components/Toggle/Toggle.test.tsx
@@ -64,7 +64,7 @@ const cleanupRenderedApp = ({ container, root }: IRenderedApp): void => {
 
 type TStylesFn = () => { track: { width: number; backgroundColor?: string; borderColor?: string } };
 
-const getStyles = (call: number): TStylesFn => mockSwitch.mock.calls[call]?.[0].styles;
+const getStyles = (call: number): TStylesFn => mockSwitch.mock.calls[call]?.[0].styles as TStylesFn;
 
 describe('Toggle', () => {
   afterEach(() => {
@@ -73,7 +73,7 @@ describe('Toggle', () => {
   });
 
   it('uses the medium class, right label position, and 50px track width by default', () => {
-    const view = renderApp(<Toggle />);
+    const view = renderApp(<Toggle labelPosition="right" />);
 
     const props = mockSwitch.mock.calls[0]?.[0];
 
@@ -87,8 +87,8 @@ describe('Toggle', () => {
   it('maps sm and lg sizes to matching class names and track widths', () => {
     const view = renderApp(
       <>
-        <Toggle size="sm" />
-        <Toggle size="lg" />
+        <Toggle labelPosition="right" size="sm" />
+        <Toggle labelPosition="right" size="lg" />
       </>,
     );
 
@@ -105,7 +105,7 @@ describe('Toggle', () => {
 
   it('forwards the change event to the user-provided onChange', () => {
     const onChange = vi.fn();
-    const view = renderApp(<Toggle onChange={onChange} />);
+    const view = renderApp(<Toggle labelPosition="right" onChange={onChange} />);
 
     const input = view.container.querySelector('input');
 
@@ -122,7 +122,7 @@ describe('Toggle', () => {
   });
 
   it('seeds isChecked from the checked prop and reflects it in the track color', () => {
-    const view = renderApp(<Toggle checked />);
+    const view = renderApp(<Toggle checked labelPosition="right" />);
 
     const track = getStyles(0)().track;
 

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,5 +6,13 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.stories.tsx"
+  ]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -6,5 +6,5 @@
     "declarationDir": "./dist/types"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/packages/core/tsconfig.test.json
+++ b/packages/core/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## 배경

pop-ui "제대로 된 기반" 세 번째 하위 프로젝트(D+B, A 다음). 22개 컴포넌트 중 9개만 테스트가 있고 13개가 무방비였다. 직전 A 작업에서 Task 1이 테스트 회귀를 냈는데 뒤늦게 발견된 게 이 작업의 계기 — 회귀 안전망을 채운다.

단 13개를 다 테스트하는 건 낭비다. pop-ui는 Mantine 래퍼라 대부분 "size className + prop 전달"이고 **Mantine 자체 동작 재테스트는 가치 없다.** 조사로 테스트 가치를 HIGH~LOW로 나눠 **HIGH+MEDIUM 7개**만 했다.

## 변경 사항 (10 커밋)

**테스트 추가 (8개 파일, 자체 로직만 검증):**
- `getMarkerHTML` — 순수 함수, 타입별 HTML 디스패처 + 조건부 필드
- `Pagination` — 페이지 산술(prev/next 델타, visible-window, overflow 가드), onPageChange
- `Toggle` — onChange 변환(user+내부상태), trackWidth 맵, checked seed
- `SearchBar` — onChange string 변환, clear 버튼 조건부, size 맵
- `Dropdown` — errorMsg→error 매핑, chevron 토글, size/chevronSize 맵
- `MapInfo` — directionHref fallback, previewHeight(=height-60), 기본 라벨, no-clientId early-return, 주소복사
- `useLocation` — geolocation 성공/에러, isActive 가드, 단일플라이트, toast
- `useMap` — addMarker 등록/content, updateMarker active 토글, map=null 가드

**테스트 인프라 (`419fa93`):**
- `tsconfig.json`이 테스트 파일을 `exclude`해서 **테스트가 typecheck를 안 거치던 false-green 상태**를 발견 → exclude 제거, 테스트도 타입 검증되게 함. 그 결과 드러난 타입 에러 10개 수정(Toggle 테스트 required prop, CalendarDatePicker mock 타이핑, DatePicker.stories import 경로).

## 테스트 철학

기존 Checkbox/Radio 패턴 계승 — **Mantine을 mock하고 "pop-ui가 넘긴 props"를 assert**(size→className, 변환된 onChange, 계산식, 기본값). "크래시 없이 렌더"·Mantine 계약 재테스트는 안 함. 순수 함수/hook은 직접 호출.

## 성격

- **프로덕션 소스 로직 불변** — 테스트 + tsconfig + 타입 정합 수정만. 컴포넌트 index.tsx 런타임 로직 0 변경.
- breaking 아님 → 릴리즈 무관.

## 검증

- `npx vitest run` → **203 passed**(기존 157 + 신규 46), 19 파일
- `yarn typecheck` + `npx tsc --noEmit` **둘 다 0 에러** — 이제 테스트 파일도 타입 검증됨(false green 박멸)

## 범위 밖 (별도)

- LOW 5개(Modal/SegmentButton/TimePicker/Tab/Tooltip) — 자체 로직이 기본값/size 맵 정도라 Mantine 재테스트에 가까움.

🤖 Generated with [Claude Code](https://claude.com/claude-code)