### PR TITLE
docs: 릴리스 절차를 changeset 흐름으로 갱신

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,4 +85,4 @@ Button, CalendarDatePicker, Checkbox, DatePicker, Dropdown, ImageInput, LottieIn
 - 타입: `yarn typecheck` (4패키지). **CI(Jenkins)가 모든 빌드 흐름에서 `yarn build` 전에 이를 강제** — 타입이 깨지면 빌드·배포가 차단된다.
 - 빌드: `yarn build` (foundation → 전체), `yarn build:core`, `yarn build:foundation`
 - Storybook: `yarn build-storybook`
-- 배포는 README의 `release/*` → Chromatic → `main` → `vX.Y.Z` 태그 절차.
+- 배포는 README의 changeset(`yarn changeset` → `yarn version-packages`) → `release/*` → Chromatic → `main` → `vX.Y.Z` 태그 절차. `package.json` 버전 수동 편집 금지.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ yarn lint
 
 ### Release packages
 
-`@pop-ui/core`와 `@pop-ui/foundation`은 같은 버전으로 배포합니다.
+`@pop-ui/core`와 `@pop-ui/foundation`은 같은 버전으로 배포합니다(changeset `linked`로 잠금).
 
-1. `release/*` 브랜치에서 두 패키지의 `package.json` 버전을 같은 값으로 올립니다.
-2. `datepop-deploy/pop-ui/release/*`에서 Chromatic staging 검증을 통과시킵니다.
-3. release 브랜치를 `main`에 머지합니다.
-4. `main` 커밋에 `vX.Y.Z` 태그를 push하면 Jenkins가 npm에 아직 없는 패키지만 publish합니다.
+버전은 [changesets](https://github.com/changesets/changesets)로 관리합니다. `package.json` 버전을 수동 편집하지 마세요.
 
-예: `v1.2.3` 태그를 push하려면 `@pop-ui/core`와 `@pop-ui/foundation`의 버전도 모두 `1.2.3`이어야 합니다.
+1. 변경을 담은 PR에서 `yarn changeset`을 실행해 changeset을 추가합니다(bump 종류·설명 입력). 두 패키지는 `linked`라 한쪽만 골라도 같이 올라갑니다.
+2. `release/*` 브랜치에서 `yarn version-packages`(= `changeset version`)로 `package.json` 버전과 `CHANGELOG.md`를 일괄 갱신하고 커밋합니다.
+3. `datepop-deploy/pop-ui/release/*`에서 Chromatic staging 검증을 통과시킵니다.
+4. release 브랜치를 `main`에 머지합니다.
+5. `main` 커밋에 `vX.Y.Z` 태그를 push하면 Jenkins가 npm에 아직 없는 패키지만 publish합니다.
+
+태그 버전은 두 패키지의 `package.json` 버전과 일치해야 합니다. 예: `v1.2.3` 태그를 push하려면 `@pop-ui/core`·`@pop-ui/foundation`이 모두 `1.2.3`이어야 하며, `version-packages`가 이를 맞춰줍니다.


### PR DESCRIPTION
## 요약
#129에서 @changesets/cli를 도입했지만 README/CLAUDE.md의 릴리스 절차는 여전히 "package.json 버전 수동 편집"으로 남아 있어 도구와 문서가 어긋난 상태였습니다. 문서를 changeset 흐름으로 맞춥니다.

## 변경
- **README** `Release packages`: `yarn changeset` → `yarn version-packages`(= `changeset version`) 절차로 갱신. linked 잠금·수동 편집 금지 명시. 태그 push→Jenkins publish 실체는 유지.
- **CLAUDE.md** 배포 참조 한 줄을 동일하게 정합.

문서만 변경(코드/빌드 영향 없음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)