### PR TITLE
chore: .gitignore에 *.tgz 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 storybook-static
 coverage
 dist
+*.tgz
 .idea/
 .yarn/cache/
 .yarn/install-state.gz


### PR DESCRIPTION
## 요약
`yarn pack` 등이 남기는 `*.tgz` 빌드 아티팩트가 추적되지 않도록 `.gitignore`에 추가합니다.

메인 체크아웃에 현재 버전(1.1.11)과 무관한 낡은 `packages/core/pop-ui-core-0.1.3.tgz`(2.1MB, 6/20자)가 방치돼 있었습니다. 이런 산출물이 실수로 커밋되는 걸 막습니다.

`git check-ignore`로 해당 경로 무시 동작 확인 완료. 파일 자체(untracked)는 각자 로컬에서 삭제하면 됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)