### PR TITLE
fix(deps): runtime 취약점 패치 (tmp, linkify-it)

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   "packageManager": "yarn@4.10.3",
   "resolutions": {
     "tar": "^6.2.1",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.6",
+    "linkify-it": "^5.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9770,12 +9770,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"linkify-it@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "linkify-it@npm:5.0.0"
+"linkify-it@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "linkify-it@npm:5.0.2"
   dependencies:
     uc.micro: "npm:^2.0.0"
-  checksum: 10/ef3b7609dda6ec0c0be8a7b879cea195f0d36387b0011660cd6711bba0ad82137f59b458b7e703ec74f11d88e7c1328e2ad9b855a8500c0ded67461a8c4519e6
+  checksum: 10/1d23387319c15f2c3d41cdada0fc2edac73afb6083e967ee051afc826f7d8d9f920e287fb7c32679b4516f60e6450853dee2b4339d7d2f313222e4b9e5be1476
   languageName: node
   linkType: hard
 
@@ -14133,10 +14133,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:^0.2.4":
-  version: 0.2.5
-  resolution: "tmp@npm:0.2.5"
-  checksum: 10/dd4b78b32385eab4899d3ae296007b34482b035b6d73e1201c4a9aede40860e90997a1452c65a2d21aee73d53e93cd167d741c3db4015d90e63b6d568a93d7ec
+"tmp@npm:^0.2.6":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 요약
dependabot high 경보 중 **runtime scope**(배포물 영향) 2건을 `resolutions`로 상향합니다.

| 패키지 | 전 → 후(설치) | 취약점 | 경로 |
|---|---|---|---|
| tmp | `^0.2.4` → `^0.2.6` (0.2.7) | path traversal (`< 0.2.6`) | resolutions로 강제되던 transitive |
| linkify-it | 신규 `^5.0.1` (5.0.2) | ReDoS quadratic scan (`<= 5.0.0`) | markdown-it → linkify-it |

## 검증
- `yarn test`: **21 파일 / 207 테스트 전부 통과**
- package.json은 resolutions 2줄만 변경

> dev scope high 4건(axios/form-data/sigstore/vite)은 이 PR 범위 밖 — 배포물 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)