### PR TITLE
fix(deps): markdown-it 취약점 패치 (runtime)

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "resolutions": {
     "tar": "^6.2.1",
     "tmp": "^0.2.6",
-    "linkify-it": "^5.0.1"
+    "linkify-it": "^5.0.1",
+    "markdown-it": "^14.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6758,7 +6758,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"entities@npm:^4.2.0, entities@npm:^4.4.0, entities@npm:^4.5.0":
+"entities@npm:^4.2.0, entities@npm:^4.5.0":
   version: 4.5.0
   resolution: "entities@npm:4.5.0"
   checksum: 10/ede2a35c9bce1aeccd055a1b445d41c75a14a2bb1cd22e242f20cf04d236cdcd7f9c859eb83f76885327bfae0c25bf03303665ee1ce3d47c5927b98b0e3e3d48
@@ -10140,19 +10140,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"markdown-it@npm:^14.0.0":
-  version: 14.1.0
-  resolution: "markdown-it@npm:14.1.0"
+"markdown-it@npm:^14.2.0":
+  version: 14.3.0
+  resolution: "markdown-it@npm:14.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
-    entities: "npm:^4.4.0"
-    linkify-it: "npm:^5.0.0"
+    entities: "npm:^4.5.0"
+    linkify-it: "npm:^5.0.2"
     mdurl: "npm:^2.0.0"
     punycode.js: "npm:^2.3.1"
     uc.micro: "npm:^2.1.0"
   bin:
     markdown-it: bin/markdown-it.mjs
-  checksum: 10/f34f921be178ed0607ba9e3e27c733642be445e9bb6b1dba88da7aafe8ba1bc5d2f1c3aa8f3fc33b49a902da4e4c08c2feadfafb290b8c7dda766208bb6483a9
+  checksum: 10/16afbae804e7ea10474389918e31036c438d00bacabb340e57769a84d8a3068f37814736483a645b6ad69e138aa491c3cac83d261b630bd6d2f6af6139c5d18b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 요약
dependabot medium(runtime scope) 대응. markdown-it의 smartquotes rule에서 `replaceAt` 문자열 연산이 quadratic 복잡도라 DoS 가능한 취약점(취약 `<= 14.1.1`, 패치 `14.2.0`)을 해소합니다.

## 변경
- `resolutions`에 `markdown-it: ^14.2.0` 추가 → 설치 **14.3.0**
- prosemirror-markdown 경유 transitive(editor 패키지), runtime scope

## 검증
- `yarn test`: **21 파일 / 207 테스트 전부 통과**
- package.json은 resolutions 1줄만 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)