### PR TITLE
[DPN-1874] Tooltip 타입 버그 수정 및 React 18 peerDep 완화

### DIFF
--- a/.changeset/fix-tooltip-type-and-react18-peerdep.md
+++ b/.changeset/fix-tooltip-type-and-react18-peerdep.md
@@ -1,0 +1,9 @@
+---
+"@pop-ui/core": patch
+"@pop-ui/foundation": patch
+---
+
+Tooltip 타입 버그 수정 및 React 18 peerDep 완화
+
+- **fix(core/Tooltip)**: `ITooltipProps`가 Mantine의 required `label`을 그대로 상속하여, pop-ui가 의도한 `content` 기반 API가 타입 에러로 막히던 문제 수정. `extends Omit<MantineTooltipProps, 'label'>`로 label을 제거하여 `content`가 유일한 텍스트 소스가 되도록 정정 (런타임 변화 없음, Button 컴포넌트가 이미 사용 중인 동일 패턴).
+- **fix(core,foundation)**: peerDependencies의 react/react-dom을 `^19.2.0` → `^18.0.0 || ^19.0.0`으로 완화. Mantine 8이 `^18.x || ^19.x`를 공식 지원하고 pop-ui 소스는 React 19 전용 API를 사용하지 않으므로, React 18 호스트 앱(inhouse 등)에서의 구조적 호환성을 명시적으로 보장.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,8 +58,8 @@
     "react-easy-crop": "^5.5.3"
   },
   "peerDependencies": {
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@mantine/carousel": "^8.3.6",

--- a/packages/core/src/components/Tooltip/types.ts
+++ b/packages/core/src/components/Tooltip/types.ts
@@ -1,6 +1,6 @@
 import type { TooltipProps as MantineTooltipProps } from '@mantine/core';
 
-export interface ITooltipProps extends MantineTooltipProps {
+export interface ITooltipProps extends Omit<MantineTooltipProps, 'label'> {
   title?: string;
   content: string;
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -45,8 +45,8 @@
   "peerDependencies": {
     "@mantine/core": "^8.3.6",
     "@mantine/hooks": "^8.3.6",
-    "react": "^19.2.0",
-    "react-dom": "^19.2.0",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0",
     "react-native-svg": ">=13.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
## 변경 유형
- [x] 버그 수정 (fix)

## 관련 티켓
- DPN-1874

## 변경 위험도
- [x] Low

## 변경 요약
pop-ui를 React 18 호스트 앱(inhouse 등)에서 소비할 때 발견된 2가지 문제를 수정합니다.

**1. Tooltip 타입 버그 수정 (`@pop-ui/core`)**
- `ITooltipProps`가 Mantine의 required `label` prop을 그대로 상속하여, pop-ui가 의도한 `content` 기반 API를 사용할 때 타입 에러(`Property 'label' is missing`)가 발생하던 문제.
- `extends Omit<MantineTooltipProps, 'label'>`로 수정하여 `content`가 유일한 텍스트 소스가 되도록 정정.
- Button 컴포넌트가 이미 사용 중인 동일한 Omit 패턴. 런타임 변화 없음 (컴포넌트가 내부적으로 `content` → Mantine `label` 슬롯에 매핑).

**2. React 18 peerDep 완화 (`@pop-ui/core`, `@pop-ui/foundation`)**
- peerDependencies의 `react`/`react-dom`을 `^19.2.0` → `^18.0.0 || ^19.0.0`으로 완화.
- 근거: Mantine 8.3.6이 공식적으로 `^18.x || ^19.x`를 지원하며, pop-ui 소스는 React 19 전용 API(use, useActionState, ref-as-prop 등)를 사용하지 않음.
- devDependencies의 react/@types/react는 19 유지 (pop-ui 자체 개발은 React 19로 진행).

## 영향 범위 / 롤백 포인트
- **영향**: 순수 타입 레벨 수정 + 선언적 peerDep 변경으로 런타임 동작 변화 없음. 호스트 앱에서 pop-ui Tooltip 사용 시 타입 에러 해소, React 18 호환성 명시적 보장.
- **롤백**: 본 PR revert. (changeset은 linked 모드라 core/foundation 동시 1.1.12로 bump 예정)

## 테스트 방법
- `yarn typecheck` (4패키지 통과)
- `yarn token-transform && yarn token-build` (토큰 재생성 — 변경 없음 확인)
- `yarn build` (foundation + core 빌드 성공)
- husky pre-commit(typecheck) / pre-push(build) 게이트 통과

## 테스트 증거
- typecheck: `Successfully ran target typecheck for 4 projects`
- build: `Successfully ran target build for 4 projects` (core.js 93.97 kB, core.umd.cjs 68.50 kB)
- token 재생성 후 `git status` 변경 0 (토큰 소스 미수정 반영)

## 체크리스트
- [x] 셀프 리뷰 완료
- [ ] 관련 테스트 추가/수정 (Tooltip 단위 테스트는 기존에 없음 — 별도 이슈 권장)
- [x] 문서 업데이트 (필요 시) — N/A
- [x] High 위험도 또는 CTO 필수 개입 항목 해당 시 에스컬레이션 여부 확인 — Low 위험도
