### PR TITLE
[DPN-2009] Jenkins checkout 인증을 App으로 전환

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ def checkoutPopUi(Map args = [:]) {
         ],
         userRemoteConfigs: [[
             url: 'https://github.com/datepop/pop-ui.git',
-            credentialsId: 'github-credentials',
+            credentialsId: 'github-app',
             refspec: refspec
         ]]
     ])


### PR DESCRIPTION
## 변경
- pop-ui explicit GitSCM checkout credential을 `github-app`으로 변경

## 검증
- GitHub App의 `datepop/pop-ui` API 접근 200 확인
- Jenkins Pipeline Model Converter 문법 검증 통과
- commit hook build/typecheck 통과
- `git diff --check` 통과

## 선행 조건
- 중앙 managed job credential 전환 PR을 먼저 머지하고 seed를 실행해야 PR scan도 `github-app`을 사용합니다.