### PR TITLE
[DPN-2016] Jenkins GitHub App 인증으로 전환

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,16 +265,11 @@ NODE
                 }
                 stage('Create GitHub Release') {
                     steps {
-                        withCredentials([string(credentialsId: 'github-pat', variable: 'GH_PAT')]) {
-                            sh '''
-                                set -eu
-                                export GH_TOKEN="$GH_PAT"
-                                gh release create "$TAG_NAME" \
-                                    --title "Release $TAG_NAME" \
-                                    --generate-notes \
-                                    || echo "[release] GitHub release already exists or could not be created"
-                            '''
-                        }
+                        createGithubReleaseIfMissing(
+                            tagName: env.TAG_NAME,
+                            title: "Release ${env.TAG_NAME}",
+                            generateNotes: true
+                        )
                     }
                 }
             }

--- a/packages/foundation/src/jenkinsfile.test.ts
+++ b/packages/foundation/src/jenkinsfile.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+
+const jenkinsfile = readFileSync('Jenkinsfile', 'utf8');
+
+describe('Jenkins GitHub release policy', () => {
+  it('uses the shared App-token release helper', () => {
+    expect(jenkinsfile).not.toContain('github' + '-pat');
+    expect(jenkinsfile).not.toContain('GH_' + 'PAT');
+    expect(jenkinsfile).not.toContain('gh release create');
+    expect(jenkinsfile).toContain('createGithubReleaseIfMissing(');
+    expect(jenkinsfile).toContain('tagName: env.TAG_NAME,');
+    expect(jenkinsfile).toContain('title: "Release ${env.TAG_NAME}",');
+    expect(jenkinsfile).toContain('generateNotes: true');
+  });
+});


### PR DESCRIPTION
## 변경 사항
- Jenkins GitHub 인증을 PAT에서 중앙 GitHub App token-file helper로 전환했습니다.
- Jenkins PR job은 비활성화 상태로 유지합니다.

## 검증
- 기존 DPN-2016 credential policy/static test 통과
- `git diff --check` 통과
- 배포는 수행하지 않았습니다.

## 선행 작업
- [datepop/.github PR #157](https://github.com/datepop/.github/pull/157) 병합 완료 (`d0ae94253d632d73cbfaca859cafdef1875271e6`)
